### PR TITLE
ci(release): adopt Changesets Action for automated versioning + publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   release:
@@ -13,15 +14,19 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: npm
       - run: npm ci
-      - run: npx changeset version
-      - run: npm run build
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This switches the release workflow to use changesets/action.\n\nWhat this does:\n- On pushes to main: if there are unreleased changesets, it opens/updates a "Version Packages" PR.\n- When the version PR is merged (into main): it runs npm publish automatically.\n- Manual trigger supported via workflow_dispatch.\n\nDetails:\n- Uses npm publish --provenance --access public.\n- Passes GITHUB_TOKEN and NPM_TOKEN to the action.\n- Uses actions/checkout with fetch-depth: 0 and actions/setup-node@v4 (Node 20).\n\nNote:\n- Ensure repo secret NPM_TOKEN is set for publishing.\n- Your local manual publish to 0.2.0 is fine; next releases can flow via changesets.\n