### PR TITLE
chore(changeset): add changeset for 'gex read' feature (minor)

### DIFF
--- a/.changeset/add-read-subcommand.md
+++ b/.changeset/add-read-subcommand.md
@@ -1,0 +1,12 @@
+---
+'@yabasha/gex': minor
+---
+
+Add `gex read` subcommand to consume previous JSON reports.
+
+- Default behavior prints `name@version` for global, dependencies, and devDependencies
+- `-r/--report <path>` to specify report file (defaults to `gex-report.json`)
+- `-i/--install` installs packages using npm:
+  - global packages → `npm i -g name@version`
+  - local dependencies → `npm i name@version`
+  - local devDependencies → `npm i -D name@version`


### PR DESCRIPTION
Adds a changeset for the new 'gex read' subcommand so the Release workflow (changesets/action) can open a Version Packages PR and publish on merge.\n\nSummary:\n- New subcommand: `gex read`\n- Default prints names@versions\n- `-r/--report` selects report file (defaults to gex-report.json)\n- `-i/--install` installs: global via `npm i -g`, local deps via `npm i`, devDeps via `npm i -D`\n