### PR TITLE
ci(release): build before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
       - run: npm ci
+      - run: npm run build
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -68,7 +68,10 @@ export async function produceReport(
       project_homepage = pkg.homepage
       if (typeof pkg.bugs === 'string') project_bugs = pkg.bugs
       else if (pkg.bugs && typeof pkg.bugs.url === 'string') project_bugs = pkg.bugs.url
-    } catch {}
+    } catch {
+      // Ignore errors reading local package.json (e.g., file missing or invalid JSON)
+      void 0
+    }
   }
 
   const globalRoot = ctx === 'global' ? await npmRootGlobal().catch(() => undefined) : undefined

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -77,7 +77,10 @@ export async function buildReportFromNpmTree(tree: any, opts: NormalizeOptions):
       const pkgJsonPath = path.join(opts.cwd || process.cwd(), 'package.json')
       const raw = await readFile(pkgJsonPath, 'utf8')
       pkgMeta = JSON.parse(raw)
-    } catch {}
+    } catch {
+      // Ignore errors reading/parsing package.json; fall back to undefined metadata
+      void 0
+    }
     if (pkgMeta?.name) report.project_name = pkgMeta.name
     if (pkgMeta?.version) report.project_version = pkgMeta.version
 


### PR DESCRIPTION
Run build prior to changesets publish in release.yml so dist/ exists before npm publish.\n\n- Add: npm run build after npm ci in release workflow\n- Keeps publish via changesets/action with provenance + public access