### PR TITLE
ci(release): export NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Set NODE_AUTH_TOKEN from NPM_TOKEN in release.yml so npm CLI authenticates reliably during publish.\n\nAction required: add an npm Automation token to repo secrets as NPM_TOKEN (if not already present). Then re-run the Release workflow.