### PR TITLE
chore(npm): add repository metadata for provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
     "tsup",
     "commander"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yabasha/yabasha-gex"
+  },
+  "homepage": "https://github.com/yabasha/yabasha-gex#readme",
+  "bugs": {
+    "url": "https://github.com/yabasha/yabasha-gex/issues"
+  },
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Add repository/homepage/bugs fields to package.json so npm provenance validation matches the GitHub repo (required for --provenance publishing).