### PR TITLE
feat: add diff command to compare two reports

### DIFF
--- a/src/runtimes/bun/commands.ts
+++ b/src/runtimes/bun/commands.ts
@@ -8,6 +8,7 @@ import { readFile } from 'node:fs/promises'
 import { Command } from 'commander'
 
 import type { OutputFormat } from '../../shared/types.js'
+import { createDiffCommand } from '../../shared/cli/diff-command.js'
 import { installFromReport, printFromReport } from '../../shared/cli/install.js'
 import { outputReport } from '../../shared/cli/output.js'
 import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
@@ -402,6 +403,7 @@ export async function createProgram(): Promise<Command> {
   createGlobalCommand(program)
   createAuditCommand(program)
   createReadCommand(program)
+  createDiffCommand(program)
 
   return program
 }

--- a/src/runtimes/node/commands.ts
+++ b/src/runtimes/node/commands.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import { Command } from 'commander'
 
 import type { OutputFormat } from '../../shared/types.js'
+import { createDiffCommand } from '../../shared/cli/diff-command.js'
 import { installFromReport, printFromReport } from '../../shared/cli/install.js'
 import { outputReport } from '../../shared/cli/output.js'
 import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
@@ -339,6 +340,7 @@ export async function createProgram(): Promise<Command> {
   createGlobalCommand(program)
   createAuditCommand(program)
   createReadCommand(program)
+  createDiffCommand(program)
 
   return program
 }

--- a/src/shared/cli/diff-command.ts
+++ b/src/shared/cli/diff-command.ts
@@ -1,0 +1,72 @@
+import path from 'node:path'
+
+import { Command } from 'commander'
+
+import { diffReports, formatDiffMarkdown, formatDiffSummary } from './diff.js'
+import { loadReportFromFile } from './parser.js'
+
+type DiffFormat = 'md' | 'json'
+
+export function createDiffCommand(program: Command): Command {
+  const diffCmd = program
+    .command('diff')
+    .description('Compare two GEX reports and show added/removed/upgraded/downgraded packages')
+    .argument('<old>', 'Path to the older report (JSON or Markdown)')
+    .argument('<new>', 'Path to the newer report (JSON or Markdown)')
+    .option(
+      '-f, --output-format <format>',
+      'Output format: md or json',
+      (val) => (val === 'json' ? 'json' : 'md'),
+      'md',
+    )
+    .option('-o, --out-file <path>', 'Write diff to file')
+    .option('--fail-on-changes', 'Exit non-zero if any changes are detected', false)
+
+  diffCmd.action(async (oldArg: string, newArg: string, opts: any) => {
+    const cwd = process.cwd()
+    const oldPath = path.resolve(cwd, oldArg)
+    const newPath = path.resolve(cwd, newArg)
+
+    let oldReport
+    let newReport
+    try {
+      oldReport = await loadReportFromFile(oldPath)
+    } catch (err: any) {
+      console.error(`Failed to read report at ${oldPath}: ${err?.message || err}`)
+      process.exitCode = 1
+      return
+    }
+    try {
+      newReport = await loadReportFromFile(newPath)
+    } catch (err: any) {
+      console.error(`Failed to read report at ${newPath}: ${err?.message || err}`)
+      process.exitCode = 1
+      return
+    }
+
+    const diff = diffReports(oldReport, newReport)
+    const format = (opts.outputFormat ?? 'md') as DiffFormat
+    const outFile = opts.outFile as string | undefined
+
+    const content = format === 'json' ? JSON.stringify(diff, null, 2) : formatDiffMarkdown(diff)
+
+    if (outFile) {
+      const { mkdir, writeFile } = await import('node:fs/promises')
+      await mkdir(path.dirname(outFile), { recursive: true })
+      await writeFile(outFile, content, 'utf8')
+      console.log(`Wrote diff to ${outFile}`)
+      console.log(formatDiffSummary(diff))
+    } else {
+      console.log(content)
+    }
+
+    if (opts.failOnChanges) {
+      const { added, removed, upgraded, downgraded } = diff.totals
+      if (added + removed + upgraded + downgraded > 0) {
+        process.exitCode = 1
+      }
+    }
+  })
+
+  return diffCmd
+}

--- a/src/shared/cli/diff.test.ts
+++ b/src/shared/cli/diff.test.ts
@@ -87,6 +87,16 @@ describe('diffReports', () => {
     expect(diff.local_dependencies.upgraded).toEqual([{ name: 'foo', from: 'a', to: 'b' }])
   })
 
+  it('surfaces version-string changes that tie on semver precedence', () => {
+    const old = emptyReport({ local_dependencies: [pkg('foo', '1.2.3+build1')] })
+    const next = emptyReport({ local_dependencies: [pkg('foo', '1.2.3+build2')] })
+
+    const diff = diffReports(old, next)
+    const changes = [...diff.local_dependencies.upgraded, ...diff.local_dependencies.downgraded]
+    expect(changes).toEqual([{ name: 'foo', from: '1.2.3+build1', to: '1.2.3+build2' }])
+    expect(diff.totals.added + diff.totals.removed).toBe(0)
+  })
+
   it('does not list packages with identical versions', () => {
     const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
     const next = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
@@ -151,7 +161,8 @@ describe('formatDiffMarkdown', () => {
   it('renders an empty diff as a no-changes section', () => {
     const diff = diffReports(emptyReport(), emptyReport())
     const md = formatDiffMarkdown(diff)
-    expect(md).toContain('# GEX Report Diff')
+    expect(md).toContain('# GEX Diff')
+    expect(md.startsWith('# GEX Report')).toBe(false)
     expect(md).toContain('_No changes_')
   })
 

--- a/src/shared/cli/diff.test.ts
+++ b/src/shared/cli/diff.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Report } from '../types.js'
+
+import { diffReports, formatDiffMarkdown, formatDiffSummary } from './diff.js'
+
+function emptyReport(overrides: Partial<Report> = {}): Report {
+  return {
+    report_version: '1.0',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    tool_version: '0.0.0',
+    global_packages: [],
+    local_dependencies: [],
+    local_dev_dependencies: [],
+    ...overrides,
+  }
+}
+
+function pkg(name: string, version: string) {
+  return { name, version, resolved_path: '' }
+}
+
+describe('diffReports', () => {
+  it('detects added local dependencies', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+    const next = emptyReport({
+      local_dependencies: [pkg('axios', '1.0.0'), pkg('zod', '3.22.0')],
+    })
+
+    const diff = diffReports(old, next)
+
+    expect(diff.local_dependencies.added).toEqual([pkg('zod', '3.22.0')])
+    expect(diff.local_dependencies.removed).toEqual([])
+    expect(diff.local_dependencies.upgraded).toEqual([])
+    expect(diff.local_dependencies.downgraded).toEqual([])
+  })
+
+  it('detects removed local dependencies', () => {
+    const old = emptyReport({
+      local_dependencies: [pkg('axios', '1.0.0'), pkg('zod', '3.22.0')],
+    })
+    const next = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+
+    const diff = diffReports(old, next)
+
+    expect(diff.local_dependencies.removed).toEqual([pkg('zod', '3.22.0')])
+    expect(diff.local_dependencies.added).toEqual([])
+  })
+
+  it('detects upgraded versions', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+    const next = emptyReport({ local_dependencies: [pkg('axios', '1.6.0')] })
+
+    const diff = diffReports(old, next)
+
+    expect(diff.local_dependencies.upgraded).toEqual([
+      { name: 'axios', from: '1.0.0', to: '1.6.0' },
+    ])
+    expect(diff.local_dependencies.downgraded).toEqual([])
+  })
+
+  it('detects downgraded versions', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.6.0')] })
+    const next = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+
+    const diff = diffReports(old, next)
+
+    expect(diff.local_dependencies.downgraded).toEqual([
+      { name: 'axios', from: '1.6.0', to: '1.0.0' },
+    ])
+    expect(diff.local_dependencies.upgraded).toEqual([])
+  })
+
+  it('treats prerelease bumps as upgrades by semver order', () => {
+    const old = emptyReport({ local_dependencies: [pkg('foo', '1.0.0-alpha.1')] })
+    const next = emptyReport({ local_dependencies: [pkg('foo', '1.0.0')] })
+
+    const diff = diffReports(old, next)
+    expect(diff.local_dependencies.upgraded).toHaveLength(1)
+  })
+
+  it('falls back to lexicographic comparison for non-semver versions', () => {
+    const old = emptyReport({ local_dependencies: [pkg('foo', 'a')] })
+    const next = emptyReport({ local_dependencies: [pkg('foo', 'b')] })
+
+    const diff = diffReports(old, next)
+    expect(diff.local_dependencies.upgraded).toEqual([{ name: 'foo', from: 'a', to: 'b' }])
+  })
+
+  it('does not list packages with identical versions', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+    const next = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+
+    const diff = diffReports(old, next)
+    expect(diff.local_dependencies.added).toEqual([])
+    expect(diff.local_dependencies.removed).toEqual([])
+    expect(diff.local_dependencies.upgraded).toEqual([])
+    expect(diff.local_dependencies.downgraded).toEqual([])
+  })
+
+  it('diffs all three sections independently', () => {
+    const old = emptyReport({
+      global_packages: [pkg('typescript', '5.0.0')],
+      local_dependencies: [pkg('axios', '1.0.0')],
+      local_dev_dependencies: [pkg('vitest', '2.0.0')],
+    })
+    const next = emptyReport({
+      global_packages: [pkg('typescript', '5.6.0')],
+      local_dependencies: [pkg('zod', '3.22.0')],
+      local_dev_dependencies: [],
+    })
+
+    const diff = diffReports(old, next)
+
+    expect(diff.global_packages.upgraded).toEqual([
+      { name: 'typescript', from: '5.0.0', to: '5.6.0' },
+    ])
+    expect(diff.local_dependencies.added).toEqual([pkg('zod', '3.22.0')])
+    expect(diff.local_dependencies.removed).toEqual([pkg('axios', '1.0.0')])
+    expect(diff.local_dev_dependencies.removed).toEqual([pkg('vitest', '2.0.0')])
+  })
+
+  it('exposes total counts', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+    const next = emptyReport({
+      local_dependencies: [pkg('axios', '1.6.0'), pkg('zod', '3.22.0')],
+    })
+
+    const diff = diffReports(old, next)
+    expect(diff.totals).toEqual({ added: 1, removed: 0, upgraded: 1, downgraded: 0 })
+  })
+})
+
+describe('formatDiffSummary', () => {
+  it('reports no changes for an empty diff', () => {
+    const diff = diffReports(emptyReport(), emptyReport())
+    expect(formatDiffSummary(diff)).toBe('No changes')
+  })
+
+  it('summarizes counts in a single line', () => {
+    const old = emptyReport({ local_dependencies: [pkg('axios', '1.0.0')] })
+    const next = emptyReport({
+      local_dependencies: [pkg('axios', '1.6.0'), pkg('zod', '3.22.0')],
+    })
+    const diff = diffReports(old, next)
+    expect(formatDiffSummary(diff)).toBe('1 added, 0 removed, 1 upgraded, 0 downgraded')
+  })
+})
+
+describe('formatDiffMarkdown', () => {
+  it('renders an empty diff as a no-changes section', () => {
+    const diff = diffReports(emptyReport(), emptyReport())
+    const md = formatDiffMarkdown(diff)
+    expect(md).toContain('# GEX Report Diff')
+    expect(md).toContain('_No changes_')
+  })
+
+  it('renders sections with appropriate tables', () => {
+    const old = emptyReport({
+      local_dependencies: [pkg('axios', '1.0.0'), pkg('to-remove', '0.1.0')],
+      local_dev_dependencies: [pkg('vitest', '2.0.0')],
+    })
+    const next = emptyReport({
+      local_dependencies: [pkg('axios', '1.6.0'), pkg('zod', '3.22.0')],
+      local_dev_dependencies: [pkg('vitest', '2.0.0')],
+    })
+
+    const diff = diffReports(old, next)
+    const md = formatDiffMarkdown(diff)
+
+    expect(md).toContain('## Local Dependencies')
+    expect(md).toContain('### Added')
+    expect(md).toContain('| zod | 3.22.0 |')
+    expect(md).toContain('### Removed')
+    expect(md).toContain('| to-remove | 0.1.0 |')
+    expect(md).toContain('### Upgraded')
+    expect(md).toContain('| axios | 1.0.0 | 1.6.0 |')
+
+    expect(md).not.toContain('## Local Dev Dependencies')
+    expect(md).not.toContain('## Global Packages')
+  })
+})

--- a/src/shared/cli/diff.ts
+++ b/src/shared/cli/diff.ts
@@ -1,0 +1,227 @@
+import type { PackageInfo, Report } from '../types.js'
+
+export type PackageChange = {
+  name: string
+  from: string
+  to: string
+}
+
+export type SectionDiff = {
+  added: PackageInfo[]
+  removed: PackageInfo[]
+  upgraded: PackageChange[]
+  downgraded: PackageChange[]
+}
+
+export type ReportDiff = {
+  global_packages: SectionDiff
+  local_dependencies: SectionDiff
+  local_dev_dependencies: SectionDiff
+  totals: {
+    added: number
+    removed: number
+    upgraded: number
+    downgraded: number
+  }
+}
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+function parseSemver(version: string): [number, number, number, string] | null {
+  const match = SEMVER_RE.exec(version.trim())
+  if (!match) return null
+  return [Number(match[1]), Number(match[2]), Number(match[3]), match[4] ?? '']
+}
+
+function compareIdentifier(a: string, b: string): number {
+  const aNum = /^\d+$/.test(a) ? Number(a) : null
+  const bNum = /^\d+$/.test(b) ? Number(b) : null
+  if (aNum !== null && bNum !== null) return aNum - bNum
+  if (aNum !== null) return -1
+  if (bNum !== null) return 1
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function comparePrerelease(a: string, b: string): number {
+  if (a === b) return 0
+  if (a === '') return 1
+  if (b === '') return -1
+  const aParts = a.split('.')
+  const bParts = b.split('.')
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i += 1) {
+    const ap = aParts[i]
+    const bp = bParts[i]
+    if (ap === undefined) return -1
+    if (bp === undefined) return 1
+    const cmp = compareIdentifier(ap, bp)
+    if (cmp !== 0) return cmp
+  }
+  return 0
+}
+
+export function compareVersions(a: string, b: string): number {
+  if (a === b) return 0
+  const aSv = parseSemver(a)
+  const bSv = parseSemver(b)
+  if (aSv && bSv) {
+    for (let i = 0; i < 3; i += 1) {
+      if (aSv[i] !== bSv[i]) return (aSv[i] as number) - (bSv[i] as number)
+    }
+    return comparePrerelease(aSv[3], bSv[3])
+  }
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function diffSection(oldList: PackageInfo[], newList: PackageInfo[]): SectionDiff {
+  const oldByName = new Map(oldList.map((p) => [p.name, p]))
+  const newByName = new Map(newList.map((p) => [p.name, p]))
+
+  const added: PackageInfo[] = []
+  const removed: PackageInfo[] = []
+  const upgraded: PackageChange[] = []
+  const downgraded: PackageChange[] = []
+
+  for (const [name, pkg] of newByName) {
+    const prev = oldByName.get(name)
+    if (!prev) {
+      added.push(pkg)
+      continue
+    }
+    if (prev.version === pkg.version) continue
+    const cmp = compareVersions(prev.version, pkg.version)
+    if (cmp < 0) upgraded.push({ name, from: prev.version, to: pkg.version })
+    else if (cmp > 0) downgraded.push({ name, from: prev.version, to: pkg.version })
+  }
+
+  for (const [name, pkg] of oldByName) {
+    if (!newByName.has(name)) removed.push(pkg)
+  }
+
+  added.sort((a, b) => a.name.localeCompare(b.name))
+  removed.sort((a, b) => a.name.localeCompare(b.name))
+  upgraded.sort((a, b) => a.name.localeCompare(b.name))
+  downgraded.sort((a, b) => a.name.localeCompare(b.name))
+
+  return { added, removed, upgraded, downgraded }
+}
+
+function isEmptySection(section: SectionDiff): boolean {
+  return (
+    section.added.length === 0 &&
+    section.removed.length === 0 &&
+    section.upgraded.length === 0 &&
+    section.downgraded.length === 0
+  )
+}
+
+function mdTable(headers: string[], rows: string[][]): string {
+  const header = `| ${headers.join(' | ')} |`
+  const sep = `| ${headers.map(() => '---').join(' | ')} |`
+  const body = rows.map((r) => `| ${r.join(' | ')} |`).join('\n')
+  return [header, sep, body].filter(Boolean).join('\n')
+}
+
+function renderSection(title: string, section: SectionDiff): string[] {
+  if (isEmptySection(section)) return []
+
+  const lines: string[] = []
+  lines.push(`## ${title}`)
+  lines.push('')
+
+  if (section.added.length > 0) {
+    lines.push('### Added')
+    lines.push(
+      mdTable(
+        ['Name', 'Version'],
+        section.added.map((p) => [p.name, p.version || '']),
+      ),
+    )
+    lines.push('')
+  }
+
+  if (section.removed.length > 0) {
+    lines.push('### Removed')
+    lines.push(
+      mdTable(
+        ['Name', 'Version'],
+        section.removed.map((p) => [p.name, p.version || '']),
+      ),
+    )
+    lines.push('')
+  }
+
+  if (section.upgraded.length > 0) {
+    lines.push('### Upgraded')
+    lines.push(
+      mdTable(
+        ['Name', 'From', 'To'],
+        section.upgraded.map((c) => [c.name, c.from, c.to]),
+      ),
+    )
+    lines.push('')
+  }
+
+  if (section.downgraded.length > 0) {
+    lines.push('### Downgraded')
+    lines.push(
+      mdTable(
+        ['Name', 'From', 'To'],
+        section.downgraded.map((c) => [c.name, c.from, c.to]),
+      ),
+    )
+    lines.push('')
+  }
+
+  return lines
+}
+
+export function formatDiffSummary(diff: ReportDiff): string {
+  const { added, removed, upgraded, downgraded } = diff.totals
+  if (added === 0 && removed === 0 && upgraded === 0 && downgraded === 0) {
+    return 'No changes'
+  }
+  return `${added} added, ${removed} removed, ${upgraded} upgraded, ${downgraded} downgraded`
+}
+
+export function formatDiffMarkdown(diff: ReportDiff): string {
+  const lines: string[] = []
+  lines.push('# GEX Report Diff')
+  lines.push('')
+  lines.push(formatDiffSummary(diff))
+  lines.push('')
+
+  const { added, removed, upgraded, downgraded } = diff.totals
+  if (added === 0 && removed === 0 && upgraded === 0 && downgraded === 0) {
+    lines.push('_No changes_')
+    return lines.join('\n')
+  }
+
+  lines.push(...renderSection('Global Packages', diff.global_packages))
+  lines.push(...renderSection('Local Dependencies', diff.local_dependencies))
+  lines.push(...renderSection('Local Dev Dependencies', diff.local_dev_dependencies))
+
+  return lines.join('\n').trimEnd()
+}
+
+export function diffReports(oldReport: Report, newReport: Report): ReportDiff {
+  const global_packages = diffSection(oldReport.global_packages, newReport.global_packages)
+  const local_dependencies = diffSection(oldReport.local_dependencies, newReport.local_dependencies)
+  const local_dev_dependencies = diffSection(
+    oldReport.local_dev_dependencies,
+    newReport.local_dev_dependencies,
+  )
+
+  const sections = [global_packages, local_dependencies, local_dev_dependencies]
+  const totals = {
+    added: sections.reduce((sum, s) => sum + s.added.length, 0),
+    removed: sections.reduce((sum, s) => sum + s.removed.length, 0),
+    upgraded: sections.reduce((sum, s) => sum + s.upgraded.length, 0),
+    downgraded: sections.reduce((sum, s) => sum + s.downgraded.length, 0),
+  }
+
+  return { global_packages, local_dependencies, local_dev_dependencies, totals }
+}

--- a/src/shared/cli/diff.ts
+++ b/src/shared/cli/diff.ts
@@ -92,9 +92,14 @@ function diffSection(oldList: PackageInfo[], newList: PackageInfo[]): SectionDif
       continue
     }
     if (prev.version === pkg.version) continue
-    const cmp = compareVersions(prev.version, pkg.version)
+    let cmp = compareVersions(prev.version, pkg.version)
+    if (cmp === 0) {
+      // Versions differ as strings but tie on semver precedence (e.g. build metadata).
+      // Fall back to lexicographic order so the change is still surfaced in the diff.
+      cmp = prev.version < pkg.version ? -1 : 1
+    }
     if (cmp < 0) upgraded.push({ name, from: prev.version, to: pkg.version })
-    else if (cmp > 0) downgraded.push({ name, from: prev.version, to: pkg.version })
+    else downgraded.push({ name, from: prev.version, to: pkg.version })
   }
 
   for (const [name, pkg] of oldByName) {
@@ -189,7 +194,7 @@ export function formatDiffSummary(diff: ReportDiff): string {
 
 export function formatDiffMarkdown(diff: ReportDiff): string {
   const lines: string[] = []
-  lines.push('# GEX Report Diff')
+  lines.push('# GEX Diff')
   lines.push('')
   lines.push(formatDiffSummary(diff))
   lines.push('')


### PR DESCRIPTION
## Summary

- Adds `gex diff <old> <new>` to both `gex-node` and `gex-bun`.
- Loads two existing reports (JSON or Markdown), prints **added**, **removed**, **upgraded**, and **downgraded** packages across global, local, and dev sections.
- Markdown output by default (good for PR comments / changelogs); JSON via `-f json`.
- `--fail-on-changes` exits non-zero when any change is detected — useful for drift detection in CI.

Version comparison uses semver ordering with prerelease handling and falls back to lexicographic for non-semver values.

## Test plan

- [x] `bun run test` — 212/212 pass (was 199, +13 new diff tests covering added/removed/upgraded/downgraded across sections, prerelease semver, lexicographic fallback, totals, and markdown rendering).
- [x] `bun run lint` clean.
- [x] `bun run build` clean.
- [x] Smoke test: generated a real local report, synthesized a "newer" report with one upgrade, one removal, and one addition. `gex diff` produced the expected markdown sections.
- [x] `--fail-on-changes` exits 1 when differences exist, 0 otherwise.
- [x] Bun runtime mirrors node behavior.

## Notes

This branch is independent of #21 (audit). When both merge, the `Report.audit` field is preserved in the diff because diff only operates on package lists; audit data is just passed through.