### PR TITLE
feat: add license inventory and allowlist enforcement

### DIFF
--- a/src/runtimes/bun/commands.ts
+++ b/src/runtimes/bun/commands.ts
@@ -9,6 +9,11 @@ import { Command } from 'commander'
 
 import type { OutputFormat } from '../../shared/types.js'
 import { createDiffCommand } from '../../shared/cli/diff-command.js'
+import {
+  formatLicenseViolations,
+  handleLicenseWorkflow,
+  parseAllowlist,
+} from '../../shared/cli/license-workflow.js'
 import { installFromReport, printFromReport } from '../../shared/cli/install.js'
 import { outputReport } from '../../shared/cli/output.js'
 import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
@@ -55,6 +60,11 @@ function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolea
       'Update outdated packages (omit package names to update every package)',
     )
     .option('--check-deprecated', 'Flag packages marked deprecated in the npm registry', false)
+    .option('--with-license', 'Include each package’s SPDX license in the report', false)
+    .option(
+      '--license-allowlist <list>',
+      'Comma-separated SPDX licenses to allow; non-empty list implies --with-license and exits non-zero on any violation',
+    )
 
   if (allowOmitDev) {
     cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
@@ -154,7 +164,19 @@ export function createLocalCommand(program: Command): Command {
     })
     if (!deprecatedResult.proceed) return
 
-    await outputReport(report, outputFormat, finalOutFile, markdownExtras)
+    const allowlist = parseAllowlist(opts.licenseAllowlist)
+    const licenseOutcome = await handleLicenseWorkflow(report, {
+      enabled: Boolean(opts.withLicense),
+      allowlist,
+    })
+
+    await outputReport(licenseOutcome.report, outputFormat, finalOutFile, markdownExtras)
+
+    if (licenseOutcome.violations.length > 0) {
+      console.error(`License allowlist violations (${licenseOutcome.violations.length}):`)
+      console.error(formatLicenseViolations(licenseOutcome.violations))
+    }
+    if (licenseOutcome.shouldFail) process.exitCode = 1
   })
 
   return localCmd
@@ -222,7 +244,19 @@ export function createGlobalCommand(program: Command): Command {
     })
     if (!deprecatedResult.proceed) return
 
-    await outputReport(report, outputFormat, finalOutFile, markdownExtras)
+    const allowlist = parseAllowlist(opts.licenseAllowlist)
+    const licenseOutcome = await handleLicenseWorkflow(report, {
+      enabled: Boolean(opts.withLicense),
+      allowlist,
+    })
+
+    await outputReport(licenseOutcome.report, outputFormat, finalOutFile, markdownExtras)
+
+    if (licenseOutcome.violations.length > 0) {
+      console.error(`License allowlist violations (${licenseOutcome.violations.length}):`)
+      console.error(formatLicenseViolations(licenseOutcome.violations))
+    }
+    if (licenseOutcome.shouldFail) process.exitCode = 1
   })
 
   return globalCmd

--- a/src/runtimes/node/commands.ts
+++ b/src/runtimes/node/commands.ts
@@ -8,6 +8,11 @@ import { Command } from 'commander'
 
 import type { OutputFormat } from '../../shared/types.js'
 import { createDiffCommand } from '../../shared/cli/diff-command.js'
+import {
+  formatLicenseViolations,
+  handleLicenseWorkflow,
+  parseAllowlist,
+} from '../../shared/cli/license-workflow.js'
 import { installFromReport, printFromReport } from '../../shared/cli/install.js'
 import { outputReport } from '../../shared/cli/output.js'
 import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
@@ -53,6 +58,11 @@ function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolea
       'Update outdated packages (omit package names to update every package)',
     )
     .option('--check-deprecated', 'Flag packages marked deprecated in the npm registry', false)
+    .option('--with-license', 'Include each package’s SPDX license in the report', false)
+    .option(
+      '--license-allowlist <list>',
+      'Comma-separated SPDX licenses to allow; non-empty list implies --with-license and exits non-zero on any violation',
+    )
 
   if (allowOmitDev) {
     cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
@@ -124,7 +134,19 @@ export function createLocalCommand(program: Command): Command {
     })
     if (!deprecatedResult.proceed) return
 
-    await outputReport(report, outputFormat, finalOutFile, markdownExtras)
+    const allowlist = parseAllowlist(opts.licenseAllowlist)
+    const licenseOutcome = await handleLicenseWorkflow(report, {
+      enabled: Boolean(opts.withLicense),
+      allowlist,
+    })
+
+    await outputReport(licenseOutcome.report, outputFormat, finalOutFile, markdownExtras)
+
+    if (licenseOutcome.violations.length > 0) {
+      console.error(`License allowlist violations (${licenseOutcome.violations.length}):`)
+      console.error(formatLicenseViolations(licenseOutcome.violations))
+    }
+    if (licenseOutcome.shouldFail) process.exitCode = 1
   })
 
   return localCmd
@@ -184,7 +206,19 @@ export function createGlobalCommand(program: Command): Command {
     })
     if (!deprecatedResult.proceed) return
 
-    await outputReport(report, outputFormat, finalOutFile, markdownExtras)
+    const allowlist = parseAllowlist(opts.licenseAllowlist)
+    const licenseOutcome = await handleLicenseWorkflow(report, {
+      enabled: Boolean(opts.withLicense),
+      allowlist,
+    })
+
+    await outputReport(licenseOutcome.report, outputFormat, finalOutFile, markdownExtras)
+
+    if (licenseOutcome.violations.length > 0) {
+      console.error(`License allowlist violations (${licenseOutcome.violations.length}):`)
+      console.error(formatLicenseViolations(licenseOutcome.violations))
+    }
+    if (licenseOutcome.shouldFail) process.exitCode = 1
   })
 
   return globalCmd

--- a/src/shared/cli/license-workflow.ts
+++ b/src/shared/cli/license-workflow.ts
@@ -1,0 +1,52 @@
+import type { Report } from '../types.js'
+
+import {
+  enrichReportWithLicenses,
+  findLicenseViolations,
+  formatLicenseViolations,
+  type LicenseViolation,
+} from './license.js'
+
+export type LicenseWorkflowOptions = {
+  enabled: boolean
+  allowlist?: string[]
+}
+
+export type LicenseWorkflowResult = {
+  report: Report
+  violations: LicenseViolation[]
+  shouldFail: boolean
+}
+
+export function parseAllowlist(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined
+  const raw = Array.isArray(value) ? value : [value]
+  const entries = raw
+    .flatMap((entry) =>
+      String(entry)
+        .split(',')
+        .map((part) => part.trim()),
+    )
+    .filter(Boolean)
+  return entries.length > 0 ? entries : []
+}
+
+export async function handleLicenseWorkflow(
+  report: Report,
+  options: LicenseWorkflowOptions,
+): Promise<LicenseWorkflowResult> {
+  const useAllowlist = Array.isArray(options.allowlist) && options.allowlist.length > 0
+  if (!options.enabled && !useAllowlist) {
+    return { report, violations: [], shouldFail: false }
+  }
+
+  const enriched = await enrichReportWithLicenses(report)
+  const violations = useAllowlist ? findLicenseViolations(enriched, options.allowlist!) : []
+  return {
+    report: enriched,
+    violations,
+    shouldFail: violations.length > 0,
+  }
+}
+
+export { formatLicenseViolations }

--- a/src/shared/cli/license.test.ts
+++ b/src/shared/cli/license.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Report } from '../types.js'
+
+import {
+  enrichReportWithLicenses,
+  findLicenseViolations,
+  normalizeLicense,
+  parseLicenseField,
+  splitSpdxExpression,
+} from './license.js'
+
+const mockReadFile = vi.fn()
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+describe('parseLicenseField', () => {
+  it('returns the license string when given a plain string', () => {
+    expect(parseLicenseField({ license: 'MIT' })).toBe('MIT')
+  })
+
+  it('returns UNKNOWN when no license field is present', () => {
+    expect(parseLicenseField({})).toBe('UNKNOWN')
+    expect(parseLicenseField(null)).toBe('UNKNOWN')
+    expect(parseLicenseField(undefined)).toBe('UNKNOWN')
+  })
+
+  it('extracts type from legacy { type, url } object form', () => {
+    expect(parseLicenseField({ license: { type: 'MIT', url: 'https://...' } })).toBe('MIT')
+  })
+
+  it('joins multiple licenses from the legacy plural array form into an OR expression', () => {
+    const pkg = {
+      licenses: [{ type: 'MIT' }, { type: 'Apache-2.0' }],
+    }
+    expect(parseLicenseField(pkg)).toBe('(MIT OR Apache-2.0)')
+  })
+
+  it('preserves SPDX expressions like "(MIT OR Apache-2.0)"', () => {
+    expect(parseLicenseField({ license: '(MIT OR Apache-2.0)' })).toBe('(MIT OR Apache-2.0)')
+  })
+
+  it('returns UNKNOWN when license has no recognizable shape', () => {
+    expect(parseLicenseField({ license: 42 })).toBe('UNKNOWN')
+    expect(parseLicenseField({ license: {} })).toBe('UNKNOWN')
+  })
+})
+
+describe('normalizeLicense', () => {
+  it('lowercases and trims the license string', () => {
+    expect(normalizeLicense('  MIT  ')).toBe('mit')
+    expect(normalizeLicense('Apache-2.0')).toBe('apache-2.0')
+  })
+
+  it('strips outer parentheses from SPDX expressions', () => {
+    expect(normalizeLicense('(MIT OR Apache-2.0)')).toBe('mit or apache-2.0')
+  })
+})
+
+describe('splitSpdxExpression', () => {
+  it('returns a single license unchanged', () => {
+    expect(splitSpdxExpression('MIT')).toEqual(['MIT'])
+  })
+
+  it('splits an OR expression', () => {
+    expect(splitSpdxExpression('(MIT OR Apache-2.0)')).toEqual(['MIT', 'Apache-2.0'])
+  })
+
+  it('splits an AND expression', () => {
+    expect(splitSpdxExpression('(MIT AND Apache-2.0)')).toEqual(['MIT', 'Apache-2.0'])
+  })
+
+  it('splits mixed AND/OR by treating both as separators', () => {
+    expect(splitSpdxExpression('(MIT OR Apache-2.0 AND BSD-3-Clause)')).toEqual([
+      'MIT',
+      'Apache-2.0',
+      'BSD-3-Clause',
+    ])
+  })
+
+  it('handles UNKNOWN as a single-entry list', () => {
+    expect(splitSpdxExpression('UNKNOWN')).toEqual(['UNKNOWN'])
+  })
+})
+
+function reportFixture(): Report {
+  return {
+    report_version: '1.0',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    tool_version: '0.0.0',
+    global_packages: [],
+    local_dependencies: [
+      { name: 'foo', version: '1.0.0', resolved_path: '/repo/node_modules/foo' },
+      { name: 'bar', version: '2.0.0', resolved_path: '/repo/node_modules/bar' },
+    ],
+    local_dev_dependencies: [
+      { name: 'devthing', version: '3.0.0', resolved_path: '/repo/node_modules/devthing' },
+    ],
+  }
+}
+
+describe('enrichReportWithLicenses', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset()
+  })
+
+  it('reads each package.json and writes a license field on each entry', async () => {
+    const manifests: Record<string, any> = {
+      '/repo/node_modules/foo/package.json': { license: 'MIT' },
+      '/repo/node_modules/bar/package.json': { license: { type: 'Apache-2.0' } },
+      '/repo/node_modules/devthing/package.json': { licenses: [{ type: 'BSD-3-Clause' }] },
+    }
+    mockReadFile.mockImplementation(async (file: string) => {
+      if (manifests[file]) return JSON.stringify(manifests[file])
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    const enriched = await enrichReportWithLicenses(reportFixture())
+    expect(enriched.local_dependencies[0].license).toBe('MIT')
+    expect(enriched.local_dependencies[1].license).toBe('Apache-2.0')
+    expect(enriched.local_dev_dependencies[0].license).toBe('BSD-3-Clause')
+  })
+
+  it('writes UNKNOWN when a package.json is missing or malformed', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    const enriched = await enrichReportWithLicenses(reportFixture())
+    for (const p of enriched.local_dependencies) expect(p.license).toBe('UNKNOWN')
+  })
+})
+
+function setAllLicenses(report: Report, license: string): Report {
+  for (const p of report.local_dependencies) p.license = license
+  for (const p of report.local_dev_dependencies) p.license = license
+  return report
+}
+
+describe('findLicenseViolations', () => {
+  it('returns nothing when every license is in the allowlist', () => {
+    const report = reportFixture()
+    report.local_dependencies[0].license = 'MIT'
+    report.local_dependencies[1].license = 'Apache-2.0'
+    report.local_dev_dependencies[0].license = 'MIT'
+
+    expect(findLicenseViolations(report, ['MIT', 'Apache-2.0'])).toEqual([])
+  })
+
+  it('flags packages whose license is not in the allowlist', () => {
+    const report = setAllLicenses(reportFixture(), 'MIT')
+    report.local_dependencies[1].license = 'GPL-3.0'
+
+    const violations = findLicenseViolations(report, ['MIT'])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      name: 'bar',
+      license: 'GPL-3.0',
+      section: 'dependencies',
+    })
+  })
+
+  it('treats SPDX OR expressions as satisfied if any part is allowed', () => {
+    const report = setAllLicenses(reportFixture(), 'MIT')
+    report.local_dependencies[0].license = '(MIT OR GPL-3.0)'
+
+    expect(findLicenseViolations(report, ['MIT'])).toEqual([])
+  })
+
+  it('treats SPDX AND expressions as violating when any part is not allowed', () => {
+    const report = setAllLicenses(reportFixture(), 'MIT')
+    report.local_dependencies[0].license = '(MIT AND GPL-3.0)'
+
+    const violations = findLicenseViolations(report, ['MIT'])
+    expect(violations).toHaveLength(1)
+    expect(violations[0].name).toBe('foo')
+  })
+
+  it('flags UNKNOWN licenses as violations regardless of allowlist', () => {
+    const report = setAllLicenses(reportFixture(), 'MIT')
+    report.local_dependencies[0].license = 'UNKNOWN'
+
+    const violations = findLicenseViolations(report, ['UNKNOWN', 'MIT'])
+    expect(violations).toHaveLength(1)
+    expect(violations[0].license).toBe('UNKNOWN')
+  })
+
+  it('matches allowlist entries case-insensitively', () => {
+    const report = reportFixture()
+    report.local_dependencies[0].license = 'mit'
+    report.local_dependencies[1].license = 'Apache-2.0'
+    report.local_dev_dependencies[0].license = 'MIT'
+
+    expect(findLicenseViolations(report, ['MIT', 'apache-2.0'])).toEqual([])
+  })
+})

--- a/src/shared/cli/license.ts
+++ b/src/shared/cli/license.ts
@@ -1,0 +1,148 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { PackageInfo, Report } from '../types.js'
+
+export const UNKNOWN_LICENSE = 'UNKNOWN'
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function pickLegacyType(entry: unknown): string | null {
+  if (typeof entry === 'string' && entry.trim()) return entry.trim()
+  if (isPlainObject(entry) && typeof entry.type === 'string' && entry.type.trim()) {
+    return entry.type.trim()
+  }
+  return null
+}
+
+export function parseLicenseField(pkg: unknown): string {
+  if (!isPlainObject(pkg)) return UNKNOWN_LICENSE
+
+  const license = pkg.license
+  if (typeof license === 'string' && license.trim()) return license.trim()
+
+  if (isPlainObject(license)) {
+    const legacy = pickLegacyType(license)
+    if (legacy) return legacy
+  }
+
+  const licenses = pkg.licenses
+  if (Array.isArray(licenses) && licenses.length > 0) {
+    const types = licenses.map(pickLegacyType).filter((v): v is string => Boolean(v))
+    if (types.length === 1) return types[0]
+    if (types.length > 1) return `(${types.join(' OR ')})`
+  }
+
+  return UNKNOWN_LICENSE
+}
+
+export function normalizeLicense(license: string): string {
+  return license
+    .trim()
+    .replace(/^\(|\)$/g, '')
+    .toLowerCase()
+}
+
+export function splitSpdxExpression(license: string): string[] {
+  const inner = license.trim().replace(/^\(|\)$/g, '')
+  const parts = inner
+    .split(/\s+(?:OR|AND)\s+/i)
+    .map((s) => s.trim())
+    .filter(Boolean)
+  return parts.length > 0 ? parts : [license]
+}
+
+async function readPackageManifest(resolvedPath: string): Promise<unknown | null> {
+  if (!resolvedPath) return null
+  const manifestPath = path.join(resolvedPath, 'package.json')
+  try {
+    const raw = await readFile(manifestPath, 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+async function enrichSection(packages: PackageInfo[]): Promise<PackageInfo[]> {
+  return Promise.all(
+    packages.map(async (pkg) => {
+      const manifest = await readPackageManifest(pkg.resolved_path)
+      const license = parseLicenseField(manifest)
+      return { ...pkg, license }
+    }),
+  )
+}
+
+export async function enrichReportWithLicenses(report: Report): Promise<Report> {
+  const [global_packages, local_dependencies, local_dev_dependencies] = await Promise.all([
+    enrichSection(report.global_packages),
+    enrichSection(report.local_dependencies),
+    enrichSection(report.local_dev_dependencies),
+  ])
+
+  return {
+    ...report,
+    global_packages,
+    local_dependencies,
+    local_dev_dependencies,
+  }
+}
+
+export type LicenseViolation = {
+  name: string
+  version: string
+  license: string
+  section: 'dependencies' | 'devDependencies' | 'global'
+}
+
+function isLicenseAllowed(license: string, allowSet: Set<string>): boolean {
+  const trimmed = license.trim()
+  if (!trimmed) return false
+  if (normalizeLicense(trimmed) === 'unknown') return false
+
+  const isStrict = /\s+AND\s+/i.test(trimmed)
+  const parts = splitSpdxExpression(trimmed).map((p) => normalizeLicense(p))
+  if (isStrict) return parts.every((p) => allowSet.has(p))
+  return parts.some((p) => allowSet.has(p))
+}
+
+export function findLicenseViolations(report: Report, allowlist: string[]): LicenseViolation[] {
+  const allowSet = new Set(allowlist.map((entry) => normalizeLicense(entry)))
+  const violations: LicenseViolation[] = []
+
+  const checkSection = (packages: PackageInfo[], section: LicenseViolation['section']) => {
+    for (const pkg of packages) {
+      const license = pkg.license ?? UNKNOWN_LICENSE
+      if (!isLicenseAllowed(license, allowSet)) {
+        violations.push({
+          name: pkg.name,
+          version: pkg.version,
+          license,
+          section,
+        })
+      }
+    }
+  }
+
+  checkSection(report.global_packages, 'global')
+  checkSection(report.local_dependencies, 'dependencies')
+  checkSection(report.local_dev_dependencies, 'devDependencies')
+
+  return violations
+}
+
+export function formatLicenseViolations(violations: LicenseViolation[]): string {
+  if (violations.length === 0) return 'No license violations'
+  const headers = ['Package', 'Version', 'License', 'Section']
+  const rows = violations.map((v) => [v.name, v.version, v.license, v.section])
+  const widths = headers.map((header, idx) =>
+    Math.max(header.length, ...rows.map((row) => row[idx].length)),
+  )
+  const formatRow = (cols: string[]) =>
+    cols.map((col, idx) => col.padEnd(widths[idx], ' ')).join('  ')
+  const lines = [formatRow(headers), formatRow(widths.map((w) => '-'.repeat(w)))]
+  for (const row of rows) lines.push(formatRow(row))
+  return lines.join('\n')
+}

--- a/src/shared/report/md.test.ts
+++ b/src/shared/report/md.test.ts
@@ -236,6 +236,32 @@ describe('renderMarkdown', () => {
     expect(result).not.toContain('Deprecated')
   })
 
+  it('should include a License column when any package has a license field', () => {
+    const reportWithLicenses: Report = {
+      ...mockReport,
+      local_dependencies: [
+        {
+          name: 'commander',
+          version: '12.1.0',
+          resolved_path: '/path/to/project/node_modules/commander',
+          license: 'MIT',
+        },
+      ],
+    }
+
+    const result = renderMarkdown(reportWithLicenses)
+    expect(result).toContain('| Name | Version | License | Path |')
+    expect(result).toContain(
+      '| commander | 12.1.0 | MIT | /path/to/project/node_modules/commander |',
+    )
+  })
+
+  it('should omit the License column when no package has a license field', () => {
+    const result = renderMarkdown(mockReport)
+    expect(result).toContain('| Name | Version | Path |')
+    expect(result).not.toContain('| Name | Version | License | Path |')
+  })
+
   it('should handle partial project metadata', () => {
     const reportWithPartialMeta = {
       ...mockReport,

--- a/src/shared/report/md.ts
+++ b/src/shared/report/md.ts
@@ -32,14 +32,20 @@ function deprecationCell(pkg: PackageInfo): string {
 
 function packageRows(
   packages: PackageInfo[],
+  showLicense: boolean,
   showDeprecated: boolean,
 ): { headers: string[]; rows: string[][] } {
-  const headers = showDeprecated
-    ? ['Name', 'Version', 'Path', 'Deprecated']
-    : ['Name', 'Version', 'Path']
+  const headers = ['Name', 'Version']
+  if (showLicense) headers.push('License')
+  headers.push('Path')
+  if (showDeprecated) headers.push('Deprecated')
+
   const rows = packages.map((p) => {
-    const base = [p.name, p.version || '', p.resolved_path || '']
-    return showDeprecated ? [...base, deprecationCell(p)] : base
+    const row = [p.name, p.version || '']
+    if (showLicense) row.push(p.license || '')
+    row.push(p.resolved_path || '')
+    if (showDeprecated) row.push(deprecationCell(p))
+    return row
   })
   return { headers, rows }
 }
@@ -153,10 +159,16 @@ export function renderMarkdown(
     lines.push('')
   }
 
+  const includeLicense =
+    report.global_packages.some((p) => p.license !== undefined) ||
+    report.local_dependencies.some((p) => p.license !== undefined) ||
+    report.local_dev_dependencies.some((p) => p.license !== undefined)
+
   if (report.global_packages.length > 0) {
     lines.push('## Global Packages')
     const { headers, rows } = packageRows(
       report.global_packages,
+      includeLicense,
       hasAnyDeprecation(report.global_packages),
     )
     lines.push(table(headers, rows))
@@ -167,6 +179,7 @@ export function renderMarkdown(
     lines.push('## Local Dependencies')
     const { headers, rows } = packageRows(
       report.local_dependencies,
+      includeLicense,
       hasAnyDeprecation(report.local_dependencies),
     )
     lines.push(table(headers, rows))
@@ -177,6 +190,7 @@ export function renderMarkdown(
     lines.push('## Local Dev Dependencies')
     const { headers, rows } = packageRows(
       report.local_dev_dependencies,
+      includeLicense,
       hasAnyDeprecation(report.local_dev_dependencies),
     )
     lines.push(table(headers, rows))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,6 +14,8 @@ export type PackageInfo = {
   resolved_path: string
   /** Deprecation message from the registry, or null if not deprecated. Only set when --check-deprecated is used. */
   deprecated?: string | null
+  /** SPDX license identifier (populated when --with-license is used) */
+  license?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `--with-license` to `gex-node` and `gex-bun` (both `local` and `global`) which enriches each `PackageInfo` with its SPDX license read from the package's `package.json`.
- Markdown output gains a `License` column when the data is present; JSON includes the field naturally.
- Adds `--license-allowlist <list>` (comma-separated) which implies `--with-license` and exits non-zero when any package's license is not in the allowlist.

### Allowlist semantics

- Matching is **case-insensitive**.
- SPDX **OR** expressions (e.g. `(MIT OR Apache-2.0)`) pass when any operand is allowed.
- SPDX **AND** expressions (e.g. `(MIT AND Apache-2.0)`) require all operands to be allowed.
- `UNKNOWN` licenses (missing or unrecognized) **always violate**, even if `UNKNOWN` is in the allowlist — this is intentional for compliance use cases.

### License field parser

Handles the common shapes seen in the wild:
- `"license": "MIT"`
- `"license": { "type": "MIT", "url": "..." }` (legacy)
- `"licenses": [{ "type": "MIT" }, { "type": "Apache-2.0" }]` (legacy plural → `(MIT OR Apache-2.0)`)
- SPDX expressions passed through untouched

## Test plan

- [x] `bun run test` — 222/222 pass (was 199, +23 license tests covering parser shapes, allowlist semantics, OR/AND handling, UNKNOWN, case-insensitivity).
- [x] `bun run lint` clean.
- [x] `bun run build` clean.
- [x] Smoke test on this repo: `gex-node local --with-license -f md` produced a License column showing all dev deps as MIT (and typescript as Apache-2.0).
- [x] `--license-allowlist mit` exits 1 with a violations table listing typescript@Apache-2.0; broader allowlist exits 0.
- [x] Bun runtime mirrors node behavior.

## Notes

This branch is independent of #21 (audit) and #22 (diff). When all three merge, the new `Report.license` field on packages is preserved through `gex diff` (diff only compares package names+versions; the license field rides along).