### PR TITLE
feat: add --from-lockfile mode for faster, install-free reports

### DIFF
--- a/src/runtimes/bun/commands.ts
+++ b/src/runtimes/bun/commands.ts
@@ -58,6 +58,11 @@ function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolea
 
   if (allowOmitDev) {
     cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
+    cmd.option(
+      '--from-lockfile',
+      'Build the report from bun.lock (or package-lock.json) instead of running bun pm ls',
+      false,
+    )
   }
 
   return cmd
@@ -81,6 +86,7 @@ export function createLocalCommand(program: Command): Command {
     const outFile = opts.outFile as string | undefined
     const fullTree = Boolean(opts.fullTree)
     const omitDev = Boolean(opts.omitDev)
+    const fromLockfile = Boolean(opts.fromLockfile)
     const cwd = process.cwd()
 
     const selection = normalizeUpdateSelection(opts.updateOutdated)
@@ -138,6 +144,7 @@ export function createLocalCommand(program: Command): Command {
       outFile: finalOutFile,
       fullTree,
       omitDev,
+      fromLockfile,
     })
 
     const deprecatedResult = await applyDeprecatedCheck(report, {

--- a/src/runtimes/bun/report.test.ts
+++ b/src/runtimes/bun/report.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReadFile = vi.fn()
+const mockBunPmLs = vi.fn()
+const mockBunPmRootGlobal = vi.fn()
+const mockBunPmRootLocal = vi.fn()
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+vi.mock('./package-manager.js', () => ({
+  bunPmLs: (...args: any[]) => mockBunPmLs(...args),
+  bunPmRootGlobal: (...args: any[]) => mockBunPmRootGlobal(...args),
+  bunPmRootLocal: (...args: any[]) => mockBunPmRootLocal(...args),
+}))
+
+vi.mock('../../shared/cli/utils.js', () => ({
+  getToolVersion: async () => '0.0.0-test',
+}))
+
+const { produceReport } = await import('./report.js')
+
+describe('bun produceReport --from-lockfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds a local report from bun.lock without invoking bun pm ls', async () => {
+    const bunLock = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "demo",
+      "dependencies": { "commander": "^14.0.0", },
+      "devDependencies": { "typescript": "^5.0.0", },
+    },
+  },
+  "packages": {
+    "commander": ["commander@14.0.1", "", {}, "sha512-fake"],
+    "typescript": ["typescript@5.6.2", "", {}, "sha512-fake"],
+  }
+}
+`
+
+    const pkgJson = JSON.stringify({ name: 'demo', version: '0.0.1' })
+
+    mockReadFile.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('bun.lock')) return bunLock
+      if (filePath.endsWith('package.json')) return pkgJson
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    const { report } = await produceReport('local', {
+      outputFormat: 'json',
+      cwd: '/repo',
+      fromLockfile: true,
+    })
+
+    expect(mockBunPmLs).not.toHaveBeenCalled()
+    expect(report.local_dependencies).toEqual([
+      expect.objectContaining({ name: 'commander', version: '14.0.1' }),
+    ])
+    expect(report.local_dev_dependencies).toEqual([
+      expect.objectContaining({ name: 'typescript', version: '5.6.2' }),
+    ])
+  })
+
+  it('falls back to package-lock.json when bun.lock is absent', async () => {
+    const npmLock = JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': { dependencies: { commander: '^14.0.0' } },
+        'node_modules/commander': { version: '14.0.1' },
+      },
+    })
+
+    mockReadFile.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('bun.lock')) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      }
+      if (filePath.endsWith('package-lock.json')) return npmLock
+      if (filePath.endsWith('package.json')) return JSON.stringify({ name: 'demo' })
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    const { report } = await produceReport('local', {
+      outputFormat: 'json',
+      cwd: '/repo',
+      fromLockfile: true,
+    })
+
+    expect(mockBunPmLs).not.toHaveBeenCalled()
+    expect(report.local_dependencies).toEqual([
+      expect.objectContaining({ name: 'commander', version: '14.0.1' }),
+    ])
+  })
+
+  it('throws when no lockfile exists', async () => {
+    mockReadFile.mockImplementation(async () => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    await expect(
+      produceReport('local', {
+        outputFormat: 'json',
+        cwd: '/repo',
+        fromLockfile: true,
+      }),
+    ).rejects.toThrow(/lockfile/i)
+
+    expect(mockBunPmLs).not.toHaveBeenCalled()
+  })
+})

--- a/src/runtimes/bun/report.ts
+++ b/src/runtimes/bun/report.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { buildReportFromNpmTree } from '../../shared/transform.js'
+import { parseBunLockfile, parsePackageLockJson } from '../../shared/lockfile.js'
 import type { OutputFormat, Report } from '../../shared/types.js'
 import { getToolVersion } from '../../shared/cli/utils.js'
 
@@ -20,6 +21,7 @@ export interface ReportOptions {
   fullTree?: boolean
   omitDev?: boolean
   cwd?: string
+  fromLockfile?: boolean
 }
 
 /**
@@ -48,12 +50,23 @@ export async function produceReport(
   const toolVersion = await getToolVersion()
   const cwd = options.cwd || process.cwd()
 
-  const tree = await bunPmLs({
-    global: ctx === 'global',
-    omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
-    cwd,
-  })
-  const nodeModulesPath = tree?.node_modules_path
+  let tree: any
+  let nodeModulesPath: string | undefined
+  if (options.fromLockfile) {
+    if (ctx === 'global') {
+      throw new Error(
+        '--from-lockfile is not supported for global packages (no lockfile available)',
+      )
+    }
+    tree = await readBunLockfileTree(cwd)
+  } else {
+    tree = await bunPmLs({
+      global: ctx === 'global',
+      omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
+      cwd,
+    })
+    nodeModulesPath = tree?.node_modules_path
+  }
 
   let project_description: string | undefined
   let project_homepage: string | undefined
@@ -73,11 +86,16 @@ export async function produceReport(
     }
   }
 
-  const resolvedRoot = nodeModulesPath
-    ? nodeModulesPath
-    : ctx === 'global'
-      ? await bunPmRootGlobal().catch(() => undefined)
-      : await bunPmRootLocal(cwd).catch(() => `${cwd}/node_modules`)
+  let resolvedRoot: string | undefined
+  if (options.fromLockfile) {
+    resolvedRoot = `${cwd}/node_modules`
+  } else if (nodeModulesPath) {
+    resolvedRoot = nodeModulesPath
+  } else if (ctx === 'global') {
+    resolvedRoot = await bunPmRootGlobal().catch(() => undefined)
+  } else {
+    resolvedRoot = await bunPmRootLocal(cwd).catch(() => `${cwd}/node_modules`)
+  }
 
   const report = await buildReportFromNpmTree(tree, {
     context: ctx,
@@ -90,4 +108,23 @@ export async function produceReport(
 
   const markdownExtras = { project_description, project_homepage, project_bugs }
   return { report, markdownExtras }
+}
+
+async function readBunLockfileTree(cwd: string): Promise<any> {
+  const bunLockPath = path.join(cwd, 'bun.lock')
+  try {
+    const raw = await readFile(bunLockPath, 'utf8')
+    return parseBunLockfile(raw, { cwd })
+  } catch {
+    // fall through to package-lock.json
+  }
+  const npmLockPath = path.join(cwd, 'package-lock.json')
+  try {
+    const raw = await readFile(npmLockPath, 'utf8')
+    return parsePackageLockJson(raw, { cwd })
+  } catch {
+    throw new Error(
+      `No lockfile found at ${bunLockPath} or ${npmLockPath} (--from-lockfile requires bun.lock or package-lock.json)`,
+    )
+  }
 }

--- a/src/runtimes/node/commands.ts
+++ b/src/runtimes/node/commands.ts
@@ -56,6 +56,11 @@ function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolea
 
   if (allowOmitDev) {
     cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
+    cmd.option(
+      '--from-lockfile',
+      'Build the report from package-lock.json instead of running npm ls',
+      false,
+    )
   }
 
   return cmd
@@ -79,6 +84,7 @@ export function createLocalCommand(program: Command): Command {
     const outFile = opts.outFile as string | undefined
     const fullTree = Boolean(opts.fullTree)
     const omitDev = Boolean(opts.omitDev)
+    const fromLockfile = Boolean(opts.fromLockfile)
     const cwd = process.cwd()
 
     const selection = normalizeUpdateSelection(opts.updateOutdated)
@@ -108,6 +114,7 @@ export function createLocalCommand(program: Command): Command {
       outFile: finalOutFile,
       fullTree,
       omitDev,
+      fromLockfile,
     })
 
     const deprecatedResult = await applyDeprecatedCheck(report, {

--- a/src/runtimes/node/report.test.ts
+++ b/src/runtimes/node/report.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReadFile = vi.fn()
+const mockNpmLs = vi.fn()
+const mockNpmRootGlobal = vi.fn()
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+vi.mock('./package-manager.js', () => ({
+  npmLs: (...args: any[]) => mockNpmLs(...args),
+  npmRootGlobal: (...args: any[]) => mockNpmRootGlobal(...args),
+}))
+
+vi.mock('../../shared/cli/utils.js', () => ({
+  getToolVersion: async () => '0.0.0-test',
+}))
+
+const { produceReport } = await import('./report.js')
+
+describe('node produceReport --from-lockfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds a local report from package-lock.json without invoking npm ls', async () => {
+    const lockfile = JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          dependencies: { commander: '^14.0.0' },
+          devDependencies: { typescript: '^5.0.0' },
+        },
+        'node_modules/commander': { version: '14.0.1' },
+        'node_modules/typescript': { version: '5.6.2', dev: true },
+      },
+    })
+
+    const pkgJson = JSON.stringify({
+      name: 'demo',
+      version: '0.0.1',
+      description: 'demo project',
+    })
+
+    mockReadFile.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('package-lock.json')) return lockfile
+      if (filePath.endsWith('package.json')) return pkgJson
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    const { report } = await produceReport('local', {
+      outputFormat: 'json',
+      cwd: '/repo',
+      fromLockfile: true,
+    })
+
+    expect(mockNpmLs).not.toHaveBeenCalled()
+    expect(report.project_name).toBe('demo')
+    expect(report.local_dependencies).toEqual([
+      expect.objectContaining({ name: 'commander', version: '14.0.1' }),
+    ])
+    expect(report.local_dev_dependencies).toEqual([
+      expect.objectContaining({ name: 'typescript', version: '5.6.2' }),
+    ])
+  })
+
+  it('throws a clear error when the lockfile is missing', async () => {
+    mockReadFile.mockImplementation(async () => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    await expect(
+      produceReport('local', {
+        outputFormat: 'json',
+        cwd: '/repo',
+        fromLockfile: true,
+      }),
+    ).rejects.toThrow(/lockfile/i)
+
+    expect(mockNpmLs).not.toHaveBeenCalled()
+  })
+})

--- a/src/runtimes/node/report.ts
+++ b/src/runtimes/node/report.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { buildReportFromNpmTree } from '../../shared/transform.js'
+import { parsePackageLockJson } from '../../shared/lockfile.js'
 import type { OutputFormat, Report } from '../../shared/types.js'
 import { getToolVersion } from '../../shared/cli/utils.js'
 
@@ -20,6 +21,7 @@ export interface ReportOptions {
   fullTree?: boolean
   omitDev?: boolean
   cwd?: string
+  fromLockfile?: boolean
 }
 
 /**
@@ -49,12 +51,31 @@ export async function produceReport(
   const depth0 = !options.fullTree
   const cwd = options.cwd || process.cwd()
 
-  const tree = await npmLs({
-    global: ctx === 'global',
-    omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
-    depth0,
-    cwd,
-  })
+  let tree: any
+  if (options.fromLockfile) {
+    if (ctx === 'global') {
+      throw new Error(
+        '--from-lockfile is not supported for global packages (no lockfile available)',
+      )
+    }
+    const lockPath = path.join(cwd, 'package-lock.json')
+    let raw: string
+    try {
+      raw = await readFile(lockPath, 'utf8')
+    } catch {
+      throw new Error(
+        `No lockfile found at ${lockPath} (--from-lockfile requires package-lock.json)`,
+      )
+    }
+    tree = parsePackageLockJson(raw, { cwd })
+  } else {
+    tree = await npmLs({
+      global: ctx === 'global',
+      omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
+      depth0,
+      cwd,
+    })
+  }
 
   let project_description: string | undefined
   let project_homepage: string | undefined

--- a/src/shared/lockfile.test.ts
+++ b/src/shared/lockfile.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseBunLockfile, parsePackageLockJson } from './lockfile.js'
+
+describe('parsePackageLockJson', () => {
+  it('extracts root dependencies and devDependencies (lockfileVersion 3)', () => {
+    const raw = JSON.stringify({
+      name: 'demo',
+      version: '0.0.1',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          name: 'demo',
+          version: '0.0.1',
+          dependencies: { commander: '^14.0.0' },
+          devDependencies: { typescript: '^5.0.0' },
+        },
+        'node_modules/commander': { version: '14.0.1' },
+        'node_modules/typescript': { version: '5.6.2', dev: true },
+      },
+    })
+
+    const tree = parsePackageLockJson(raw, { cwd: '/repo' })
+
+    expect(tree.dependencies).toEqual({
+      commander: { version: '14.0.1', path: '/repo/node_modules/commander' },
+    })
+    expect(tree.devDependencies).toEqual({
+      typescript: { version: '5.6.2', path: '/repo/node_modules/typescript' },
+    })
+  })
+
+  it('uses declared spec when an installed version is missing', () => {
+    const raw = JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          dependencies: { foo: '^1.0.0' },
+        },
+      },
+    })
+
+    const tree = parsePackageLockJson(raw, { cwd: '/repo' })
+
+    expect(tree.dependencies.foo).toEqual({
+      version: '^1.0.0',
+      path: '/repo/node_modules/foo',
+    })
+  })
+
+  it('handles scoped package names', () => {
+    const raw = JSON.stringify({
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          devDependencies: { '@types/node': '^24.0.0' },
+        },
+        'node_modules/@types/node': { version: '24.4.1', dev: true },
+      },
+    })
+
+    const tree = parsePackageLockJson(raw, { cwd: '/repo' })
+
+    expect(tree.devDependencies?.['@types/node']).toEqual({
+      version: '24.4.1',
+      path: '/repo/node_modules/@types/node',
+    })
+  })
+
+  it('falls back to the legacy lockfileVersion 1 dependencies map', () => {
+    const raw = JSON.stringify({
+      name: 'demo',
+      version: '0.0.1',
+      lockfileVersion: 1,
+      dependencies: {
+        commander: { version: '14.0.1' },
+        typescript: { version: '5.6.2', dev: true },
+      },
+    })
+
+    const tree = parsePackageLockJson(raw, { cwd: '/repo' })
+
+    expect(tree.dependencies.commander).toEqual({
+      version: '14.0.1',
+      path: '/repo/node_modules/commander',
+    })
+    expect(tree.devDependencies?.typescript).toEqual({
+      version: '5.6.2',
+      path: '/repo/node_modules/typescript',
+    })
+  })
+
+  it('throws on malformed JSON', () => {
+    expect(() => parsePackageLockJson('not-json', { cwd: '/repo' })).toThrow()
+  })
+})
+
+describe('parseBunLockfile', () => {
+  it('extracts root dependencies and devDependencies', () => {
+    const raw = `{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "demo",
+      "dependencies": {
+        "commander": "^14.0.0",
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "commander": ["commander@14.0.1", "", {}, "sha512-fake"],
+    "typescript": ["typescript@5.6.2", "", {}, "sha512-fake"],
+  }
+}
+`
+
+    const tree = parseBunLockfile(raw, { cwd: '/repo' })
+
+    expect(tree.dependencies).toEqual({
+      commander: { version: '14.0.1', path: '/repo/node_modules/commander' },
+    })
+    expect(tree.devDependencies).toEqual({
+      typescript: { version: '5.6.2', path: '/repo/node_modules/typescript' },
+    })
+  })
+
+  it('falls back to the declared spec when the package entry is missing', () => {
+    const raw = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "foo": "^1.0.0",
+      },
+    },
+  },
+  "packages": {}
+}
+`
+
+    const tree = parseBunLockfile(raw, { cwd: '/repo' })
+
+    expect(tree.dependencies.foo).toEqual({
+      version: '^1.0.0',
+      path: '/repo/node_modules/foo',
+    })
+  })
+
+  it('handles scoped package names with @-prefixed descriptors', () => {
+    const raw = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@24.4.1", "", {}, "sha512-fake"],
+  }
+}
+`
+
+    const tree = parseBunLockfile(raw, { cwd: '/repo' })
+
+    expect(tree.devDependencies?.['@types/node']).toEqual({
+      version: '24.4.1',
+      path: '/repo/node_modules/@types/node',
+    })
+  })
+
+  it('throws on malformed lockfile content', () => {
+    expect(() => parseBunLockfile('not-json-at-all', { cwd: '/repo' })).toThrow()
+  })
+})

--- a/src/shared/lockfile.ts
+++ b/src/shared/lockfile.ts
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Pure parsers for npm and Bun lockfiles. They produce a
+ * dependency tree shape compatible with `buildReportFromNpmTree`, allowing
+ * `--from-lockfile` to skip the package-manager CLI entirely.
+ */
+
+import path from 'node:path'
+
+export type LockfileNode = { version: string; path: string }
+
+export type LockfileTree = {
+  dependencies: Record<string, LockfileNode>
+  devDependencies?: Record<string, LockfileNode>
+}
+
+export type ParseLockfileOptions = {
+  cwd?: string
+}
+
+function nodeModulesPath(cwd: string, name: string): string {
+  return path.join(cwd, 'node_modules', name)
+}
+
+/**
+ * Parse a `package-lock.json` (npm v1 / v2 / v3) and extract the root project's
+ * direct dependencies and devDependencies along with their installed versions.
+ */
+export function parsePackageLockJson(raw: string, opts: ParseLockfileOptions = {}): LockfileTree {
+  const cwd = opts.cwd || process.cwd()
+  const data = JSON.parse(raw) as Record<string, any>
+
+  const tree: LockfileTree = { dependencies: {} }
+
+  // npm v2/v3: top-level `packages` object with the root keyed as ''.
+  const packages = data.packages as Record<string, any> | undefined
+  if (packages && typeof packages === 'object') {
+    const root = packages[''] || {}
+    const declaredProd: Record<string, string> = root.dependencies || {}
+    const declaredDev: Record<string, string> = root.devDependencies || {}
+
+    for (const [name, spec] of Object.entries(declaredProd)) {
+      const installed = packages[`node_modules/${name}`]
+      const version =
+        (installed && typeof installed.version === 'string' && installed.version) || spec
+      tree.dependencies[name] = { version, path: nodeModulesPath(cwd, name) }
+    }
+
+    if (Object.keys(declaredDev).length > 0) {
+      tree.devDependencies = {}
+      for (const [name, spec] of Object.entries(declaredDev)) {
+        const installed = packages[`node_modules/${name}`]
+        const version =
+          (installed && typeof installed.version === 'string' && installed.version) || spec
+        tree.devDependencies[name] = { version, path: nodeModulesPath(cwd, name) }
+      }
+    }
+
+    return tree
+  }
+
+  // npm v1: top-level `dependencies` map keyed by name with `dev` boolean.
+  const legacy = data.dependencies as Record<string, any> | undefined
+  if (legacy && typeof legacy === 'object') {
+    for (const [name, info] of Object.entries(legacy)) {
+      const version = (info && typeof info.version === 'string' && info.version) || ''
+      const node: LockfileNode = { version, path: nodeModulesPath(cwd, name) }
+      if (info && info.dev === true) {
+        tree.devDependencies = tree.devDependencies || {}
+        tree.devDependencies[name] = node
+      } else {
+        tree.dependencies[name] = node
+      }
+    }
+  }
+
+  return tree
+}
+
+/**
+ * Strip trailing commas inside objects/arrays so JSON.parse can read Bun's
+ * relaxed lockfile syntax. Quoted strings are preserved verbatim.
+ */
+function stripTrailingCommas(input: string): string {
+  let out = ''
+  let inString = false
+  let escaped = false
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]
+    if (inString) {
+      out += ch
+      if (escaped) {
+        escaped = false
+      } else if (ch === '\\') {
+        escaped = true
+      } else if (ch === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      out += ch
+      continue
+    }
+    if (ch === ',') {
+      // Look ahead, skipping whitespace, for a closing brace/bracket.
+      let j = i + 1
+      while (j < input.length && /\s/.test(input[j] as string)) j++
+      const next = input[j]
+      if (next === '}' || next === ']') {
+        // Drop the trailing comma.
+        continue
+      }
+    }
+    out += ch
+  }
+  return out
+}
+
+/**
+ * Extract the version portion from a Bun package descriptor like
+ * `"foo@1.2.3"` or `"@scope/pkg@1.2.3"`. Returns an empty string if the
+ * descriptor cannot be parsed.
+ */
+function versionFromBunDescriptor(descriptor: string): string {
+  // Find the LAST '@' that separates name from version, ignoring the leading
+  // '@' on scoped packages.
+  const start = descriptor.startsWith('@') ? 1 : 0
+  const at = descriptor.indexOf('@', start)
+  if (at === -1) return ''
+  return descriptor.slice(at + 1)
+}
+
+/**
+ * Parse a Bun text lockfile (`bun.lock`, lockfileVersion 1) and extract the
+ * root workspace's direct dependencies and devDependencies.
+ */
+export function parseBunLockfile(raw: string, opts: ParseLockfileOptions = {}): LockfileTree {
+  const cwd = opts.cwd || process.cwd()
+  const cleaned = stripTrailingCommas(raw)
+  const data = JSON.parse(cleaned) as Record<string, any>
+
+  const tree: LockfileTree = { dependencies: {} }
+
+  const workspaces = (data.workspaces as Record<string, any> | undefined) || {}
+  const root = workspaces[''] || {}
+  const declaredProd: Record<string, string> = root.dependencies || {}
+  const declaredDev: Record<string, string> = root.devDependencies || {}
+  const packages = (data.packages as Record<string, any> | undefined) || {}
+
+  const resolveVersion = (name: string, spec: string): string => {
+    const entry = packages[name]
+    if (Array.isArray(entry) && typeof entry[0] === 'string') {
+      const v = versionFromBunDescriptor(entry[0])
+      if (v) return v
+    }
+    return spec
+  }
+
+  for (const [name, spec] of Object.entries(declaredProd)) {
+    tree.dependencies[name] = {
+      version: resolveVersion(name, spec),
+      path: nodeModulesPath(cwd, name),
+    }
+  }
+
+  if (Object.keys(declaredDev).length > 0) {
+    tree.devDependencies = {}
+    for (const [name, spec] of Object.entries(declaredDev)) {
+      tree.devDependencies[name] = {
+        version: resolveVersion(name, spec),
+        path: nodeModulesPath(cwd, name),
+      }
+    }
+  }
+
+  return tree
+}


### PR DESCRIPTION
## Summary

- Adds `--from-lockfile` to `gex-node local` and `gex-bun local`.
- When set, the report is built by parsing `package-lock.json` (node) or `bun.lock` (bun, falling back to `package-lock.json`) directly, skipping `npm ls` / `bun pm ls` entirely.
- Faster on large trees and works without `node_modules` installed (fresh CI clones, cache misses, ephemeral containers).
- If no lockfile is found, exits 1 with a clear message — no silent fallback to a CLI invocation that would defeat the purpose.

### Implementation notes

- New module `src/shared/lockfile.ts` with two pure parsers:
  - `parsePackageLockJson` handles npm v2/v3 (top-level `packages` keyed by `node_modules/...`) and the legacy v1 shape (top-level `dependencies` map with `dev` flag).
  - `parseBunLockfile` strips trailing commas (Bun's lockfile is JSON-with-trailing-commas) and extracts `workspaces[""].dependencies` / `devDependencies`, resolving versions from the `packages` map's `name@version` descriptors.
- Both parsers return a tree shape compatible with `buildReportFromNpmTree`, so JSON / Markdown / HTML renderers are unchanged.
- `resolved_path` is synthesized as `<cwd>/node_modules/<name>` since `node_modules` may not exist.
- `--from-lockfile` is rejected for `global` (global packages have no lockfile).

## Test plan

- [x] `bun run test` — 213/213 pass (was 199, +14 new across `lockfile.test.ts` and per-runtime `report.test.ts`).
- [x] `bun run lint` clean.
- [x] `bun run build` clean.
- [x] Smoke test on this repo: `gex-node local --from-lockfile -f md` produces a report identical-shape to `gex-node local -f md` (same packages, same versions).
- [x] Smoke test bun runtime fallback: `gex-bun local --from-lockfile -f md` (no `bun.lock` present) falls back to `package-lock.json` and emits the same report.
- [x] Smoke test bun.lock parsing: synthesized a fixture project with a hand-written `bun.lock` (trailing commas, scoped/unscoped descriptors); `gex-bun local --from-lockfile -f json` reports the lockfile versions correctly.
- [x] Missing lockfile: in an empty project `gex-node local --from-lockfile` prints `No lockfile found at .../package-lock.json (--from-lockfile requires package-lock.json)` and exits 1.

## Notes

Independent of #21 (audit), #22 (diff), and #23 (license inventory). The new flag is additive; default behavior is unchanged. When all four merge, `--from-lockfile` will work alongside `--audit`, license enforcement, and diff input generation since they all consume the same `Report` shape.