### PR TITLE
feat: Yarn and pnpm runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "gex": "./dist/cli.cjs",
     "gex-node": "./dist/cli-node.cjs",
     "gex-bun": "./dist/cli-bun.mjs",
+    "gex-yarn": "./dist/cli-yarn.cjs",
+    "gex-pnpm": "./dist/cli-pnpm.cjs",
     "gb": "./dist/cli-bun.mjs",
     "gn": "./dist/cli-node.cjs"
   },

--- a/src/runtimes/pnpm/cli.entry.ts
+++ b/src/runtimes/pnpm/cli.entry.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview pnpm CLI entrypoint for the `gex-pnpm` binary.
+ *
+ * Thin wrapper that invokes the shared pnpm runtime `run` function when the
+ * generated bundle is executed as the main module.
+ */
+
+import { run } from './cli.js'
+
+const isMainModule = (() => {
+  try {
+    if (typeof require !== 'undefined' && typeof module !== 'undefined') {
+      return (require as any).main === module
+    }
+    if (typeof import.meta !== 'undefined') {
+      return import.meta.url === `file://${process.argv[1]}`
+    }
+    return false
+  } catch {
+    return false
+  }
+})()
+
+if (isMainModule) {
+  run().catch((error) => {
+    console.error('pnpm CLI error:', error)
+    process.exitCode = 1
+  })
+}

--- a/src/runtimes/pnpm/cli.ts
+++ b/src/runtimes/pnpm/cli.ts
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview pnpm CLI runner for GEX dependency auditing tool
+ *
+ * This module only exports the `run` function and does not auto-execute
+ * itself. Binary entrypoints (e.g. `cli-pnpm`) are responsible for invoking
+ * `run()` when appropriate so this file can be safely imported by other
+ * entrypoints without triggering side effects.
+ */
+
+import { createProgram } from './commands.js'
+
+export async function run(argv = process.argv): Promise<void> {
+  const program = await createProgram()
+  await program.parseAsync(argv)
+}

--- a/src/runtimes/pnpm/commands.ts
+++ b/src/runtimes/pnpm/commands.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview CLI command definitions and handlers for the pnpm runtime.
+ */
+
+import path from 'node:path'
+
+import { Command } from 'commander'
+
+import type { OutputFormat } from '../../shared/types.js'
+import { installFromReport, printFromReport } from '../../shared/cli/install.js'
+import { outputReport } from '../../shared/cli/output.js'
+import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
+import { ASCII_BANNER, getToolVersion } from '../../shared/cli/utils.js'
+
+import { produceReport } from './report.js'
+
+function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolean }): Command {
+  cmd
+    .option(
+      '-f, --output-format <format>',
+      'Output format: md or json',
+      (val) => (val === 'md' ? 'md' : 'json'),
+      'json',
+    )
+    .option('-o, --out-file <path>', 'Write report to file')
+    .option('--full-tree', 'Include full pnpm list tree (when available)', false)
+
+  if (allowOmitDev) {
+    cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
+  }
+
+  return cmd
+}
+
+export function createLocalCommand(program: Command): Command {
+  const localCmd = program
+    .command('local', { isDefault: true })
+    .description("Generate a report for the current pnpm project's dependencies")
+
+  addCommonOptions(localCmd, { allowOmitDev: true })
+
+  localCmd.action(async (opts) => {
+    const outputFormat = (opts.outputFormat ?? 'json') as OutputFormat
+    const outFile = opts.outFile as string | undefined
+    const fullTree = Boolean(opts.fullTree)
+    const omitDev = Boolean(opts.omitDev)
+
+    const { report, markdownExtras } = await produceReport('local', {
+      outputFormat,
+      outFile,
+      fullTree,
+      omitDev,
+    })
+
+    await outputReport(report, outputFormat, outFile, markdownExtras)
+  })
+
+  return localCmd
+}
+
+export function createGlobalCommand(program: Command): Command {
+  const globalCmd = program
+    .command('global')
+    .description('Generate a report of globally installed pnpm packages')
+
+  addCommonOptions(globalCmd, { allowOmitDev: false })
+
+  globalCmd.action(async (opts) => {
+    const outputFormat = (opts.outputFormat ?? 'json') as OutputFormat
+    const outFile = opts.outFile as string | undefined
+    const fullTree = Boolean(opts.fullTree)
+
+    const { report, markdownExtras } = await produceReport('global', {
+      outputFormat,
+      outFile,
+      fullTree,
+    })
+
+    await outputReport(report, outputFormat, outFile, markdownExtras)
+  })
+
+  return globalCmd
+}
+
+export function createReadCommand(program: Command): Command {
+  const readCmd = program
+    .command('read')
+    .description(
+      'Read a previously generated report (JSON or Markdown) and either print package names or install them',
+    )
+    .argument('[report]', 'Path to report file (JSON or Markdown)', 'pnpm-report.json')
+    .option('-r, --report <path>', 'Path to report file (JSON or Markdown)')
+    .option('-p, --print', 'Print package names/versions from the report (default)', false)
+    .option('-i, --install', 'Install packages from the report using pnpm', false)
+
+  readCmd.action(async (reportArg: string | undefined, opts: any) => {
+    const chosen = (opts.report as string | undefined) || reportArg || 'pnpm-report.json'
+    const reportPath = path.resolve(process.cwd(), chosen)
+
+    try {
+      const parsed = await loadReportFromFile(reportPath)
+
+      const doInstall = Boolean(opts.install)
+      const doPrint = Boolean(opts.print) || !doInstall
+
+      if (doPrint) {
+        printFromReport(parsed)
+      }
+      if (doInstall) {
+        await installFromReport(parsed, { cwd: process.cwd(), packageManager: 'pnpm' })
+      }
+    } catch (err: any) {
+      const isMd = isMarkdownReportFile(reportPath)
+      const hint = isMd
+        ? 'Try generating a JSON report with: gex-pnpm global -f json -o global.json, then: gex-pnpm read global.json'
+        : 'Specify a report path with: gex-pnpm read <path-to-report.json>'
+      console.error(`Failed to read report at ${reportPath}: ${err?.message || err}`)
+      console.error(hint)
+      process.exitCode = 1
+    }
+  })
+
+  return readCmd
+}
+
+export async function createProgram(): Promise<Command> {
+  const program = new Command()
+    .name('gex-pnpm')
+    .description('GEX: Dependency auditing and documentation for pnpm (local and global).')
+    .version(await getToolVersion())
+
+  program.addHelpText('beforeAll', `\n${ASCII_BANNER}`)
+
+  createLocalCommand(program)
+  createGlobalCommand(program)
+  createReadCommand(program)
+
+  return program
+}

--- a/src/runtimes/pnpm/package-manager.test.ts
+++ b/src/runtimes/pnpm/package-manager.test.ts
@@ -1,0 +1,167 @@
+import { promisify } from 'node:util'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { pnpmPmLs, pnpmRootGlobal } from './package-manager.js'
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}))
+
+vi.mock('node:util', () => ({
+  promisify: vi.fn(),
+}))
+
+const mockPromisify = vi.mocked(promisify)
+const mockExecFileAsync = vi.fn()
+
+describe('pnpm package manager helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPromisify.mockReturnValue(mockExecFileAsync)
+  })
+
+  describe('pnpmPmLs (local)', () => {
+    it('parses pnpm list JSON array output', async () => {
+      const stdout = JSON.stringify([
+        {
+          name: 'myapp',
+          version: '0.1.0',
+          path: '/repo',
+          dependencies: {
+            commander: {
+              from: 'commander',
+              version: '14.0.1',
+              resolved: 'https://registry.npmjs.org/commander/-/commander-14.0.1.tgz',
+              path: '/repo/node_modules/.pnpm/commander@14.0.1/node_modules/commander',
+            },
+          },
+          devDependencies: {
+            vitest: {
+              from: 'vitest',
+              version: '3.2.4',
+              resolved: 'https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz',
+              path: '/repo/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest',
+            },
+          },
+        },
+      ])
+      mockExecFileAsync.mockResolvedValue({ stdout, stderr: '' })
+
+      const tree = await pnpmPmLs({ cwd: '/repo' })
+
+      expect(tree.dependencies).toEqual({
+        commander: {
+          version: '14.0.1',
+          path: '/repo/node_modules/.pnpm/commander@14.0.1/node_modules/commander',
+        },
+      })
+      expect(tree.devDependencies).toEqual({
+        vitest: {
+          version: '3.2.4',
+          path: '/repo/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest',
+        },
+      })
+    })
+
+    it('omits devDependencies when omitDev is set and passes --prod to pnpm', async () => {
+      const stdout = JSON.stringify([
+        {
+          name: 'myapp',
+          path: '/repo',
+          dependencies: {
+            commander: { version: '14.0.1', path: '/repo/node_modules/commander' },
+          },
+        },
+      ])
+      mockExecFileAsync.mockResolvedValue({ stdout, stderr: '' })
+
+      const tree = await pnpmPmLs({ cwd: '/repo', omitDev: true })
+
+      expect(tree.dependencies).toHaveProperty('commander')
+      expect(tree.devDependencies).toBeUndefined()
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'pnpm',
+        expect.arrayContaining(['list', '--json', '--depth=0', '--prod']),
+        expect.objectContaining({ cwd: '/repo' }),
+      )
+    })
+
+    it('returns empty tree when pnpm output is empty', async () => {
+      mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' })
+
+      const tree = await pnpmPmLs({ cwd: '/repo' })
+
+      expect(tree.dependencies).toEqual({})
+      expect(tree.devDependencies).toEqual({})
+    })
+
+    it('falls back gracefully on missing version/path fields', async () => {
+      const stdout = JSON.stringify([
+        {
+          name: 'myapp',
+          dependencies: {
+            'no-version': { from: 'no-version' },
+          },
+        },
+      ])
+      mockExecFileAsync.mockResolvedValue({ stdout, stderr: '' })
+
+      const tree = await pnpmPmLs({ cwd: '/repo' })
+
+      expect(tree.dependencies['no-version']).toEqual({ version: '', path: '' })
+    })
+
+    it('throws a helpful error when pnpm fails without recoverable stdout', async () => {
+      const error = new Error('pnpm exited 1') as any
+      error.stderr = 'ERR_PNPM_NO_LOCKFILE'
+      mockExecFileAsync.mockRejectedValue(error)
+
+      await expect(pnpmPmLs({ cwd: '/repo' })).rejects.toThrow(/pnpm list/)
+    })
+  })
+
+  describe('pnpmPmLs (global)', () => {
+    it('passes --global when listing globals', async () => {
+      const stdout = JSON.stringify([
+        {
+          name: '<global>',
+          dependencies: {
+            typescript: { version: '5.4.0', path: '/g/node_modules/typescript' },
+          },
+        },
+      ])
+      mockExecFileAsync.mockResolvedValue({ stdout, stderr: '' })
+
+      const tree = await pnpmPmLs({ global: true })
+
+      expect(tree.dependencies).toHaveProperty('typescript')
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'pnpm',
+        expect.arrayContaining(['list', '--json', '--depth=0', '--global']),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('pnpmRootGlobal', () => {
+    it('returns the trimmed pnpm root -g path', async () => {
+      mockExecFileAsync.mockResolvedValue({
+        stdout: '/Users/me/Library/pnpm/global/5/node_modules\n',
+        stderr: '',
+      })
+
+      const result = await pnpmRootGlobal()
+
+      expect(result).toBe('/Users/me/Library/pnpm/global/5/node_modules')
+    })
+
+    it('throws when pnpm root -g fails', async () => {
+      const error = new Error('pnpm root failed') as any
+      error.stderr = 'pnpm: command not found'
+      mockExecFileAsync.mockRejectedValue(error)
+
+      await expect(pnpmRootGlobal()).rejects.toThrow(/pnpm root/)
+    })
+  })
+})

--- a/src/runtimes/pnpm/package-manager.ts
+++ b/src/runtimes/pnpm/package-manager.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview pnpm command execution utilities for dependency analysis.
+ */
+
+import { promisify } from 'node:util'
+
+export type PnpmPmLsOptions = {
+  global?: boolean
+  omitDev?: boolean
+  cwd?: string
+}
+
+type PackageNode = {
+  version: string
+  path: string
+}
+
+type PnpmPackageTree = {
+  dependencies: Record<string, PackageNode>
+  devDependencies?: Record<string, PackageNode>
+  node_modules_path?: string
+}
+
+async function getExecFileAsync(): Promise<
+  (
+    command: string,
+    args?: readonly string[] | null,
+    options?: any,
+  ) => Promise<{ stdout: string; stderr: string }>
+> {
+  const { execFile } = await import('node:child_process')
+  return promisify(execFile) as any
+}
+
+/**
+ * Lists installed packages reported by pnpm.
+ *
+ * `pnpm list --json --depth=0` emits a JSON array; entry zero contains
+ * `dependencies` / `devDependencies` shaped like `{ name: { version, path } }`.
+ */
+export async function pnpmPmLs(options: PnpmPmLsOptions = {}): Promise<PnpmPackageTree> {
+  const args = ['list', '--json', '--depth=0']
+  if (options.global) args.push('--global')
+  if (options.omitDev) args.push('--prod')
+
+  let stdout = ''
+  try {
+    const execFileAsync = await getExecFileAsync()
+    const result = await execFileAsync('pnpm', args, {
+      cwd: options.cwd,
+      maxBuffer: 10 * 1024 * 1024,
+    })
+    stdout = result.stdout
+  } catch (err: any) {
+    const errStdout = typeof err?.stdout === 'string' ? err.stdout : ''
+    if (errStdout.trim()) {
+      stdout = errStdout
+    } else {
+      const stderr = typeof err?.stderr === 'string' ? err.stderr.trim() : ''
+      const msg = stderr || err?.message || 'pnpm list failed'
+      throw new Error(`pnpm list failed: ${msg}`)
+    }
+  }
+
+  if (!stdout || !stdout.trim()) {
+    return {
+      dependencies: {},
+      devDependencies: options.omitDev ? undefined : {},
+    }
+  }
+
+  let parsed: any
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return {
+      dependencies: {},
+      devDependencies: options.omitDev ? undefined : {},
+    }
+  }
+
+  const root = Array.isArray(parsed) ? parsed[0] || {} : parsed || {}
+
+  return {
+    dependencies: normalizeDeps(root.dependencies),
+    devDependencies: options.omitDev ? undefined : normalizeDeps(root.devDependencies),
+    node_modules_path: typeof root.path === 'string' ? `${root.path}/node_modules` : undefined,
+  }
+}
+
+/**
+ * Returns the trimmed `pnpm root -g` global node_modules directory.
+ */
+export async function pnpmRootGlobal(): Promise<string> {
+  try {
+    const execFileAsync = await getExecFileAsync()
+    const { stdout } = await execFileAsync('pnpm', ['root', '-g'])
+    return stdout.trim()
+  } catch (err: any) {
+    const stderr = typeof err?.stderr === 'string' ? err.stderr.trim() : ''
+    const msg = stderr || err?.message || 'pnpm root -g failed'
+    throw new Error(`pnpm root -g failed: ${msg}`)
+  }
+}
+
+function normalizeDeps(obj: any): Record<string, PackageNode> {
+  if (!obj || typeof obj !== 'object') return {}
+  const result: Record<string, PackageNode> = {}
+  for (const [name, info] of Object.entries(obj as Record<string, any>)) {
+    if (!info || typeof info !== 'object') continue
+    const version = typeof (info as any).version === 'string' ? (info as any).version : ''
+    const pkgPath = typeof (info as any).path === 'string' ? (info as any).path : ''
+    result[name] = { version, path: pkgPath }
+  }
+  return result
+}

--- a/src/runtimes/pnpm/report.test.ts
+++ b/src/runtimes/pnpm/report.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./package-manager.js', () => ({
+  pnpmPmLs: vi.fn(),
+  pnpmRootGlobal: vi.fn(),
+}))
+
+const mockReadFile = vi.fn()
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+vi.mock('../../shared/cli/utils.js', () => ({
+  getToolVersion: vi.fn().mockResolvedValue('test-tool-version'),
+  ASCII_BANNER: '',
+}))
+
+const pmModule = await import('./package-manager.js')
+const reportModule = await import('./report.js')
+
+const mockPnpmPmLs = vi.mocked(pmModule.pnpmPmLs)
+const mockPnpmRootGlobal = vi.mocked(pmModule.pnpmRootGlobal)
+
+describe('pnpm produceReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockReadFile.mockReset()
+  })
+
+  it('builds a local report from the pnpm tree', async () => {
+    mockPnpmPmLs.mockResolvedValue({
+      dependencies: {
+        commander: {
+          version: '14.0.1',
+          path: '/repo/node_modules/.pnpm/commander@14.0.1/node_modules/commander',
+        },
+      },
+      devDependencies: {
+        vitest: {
+          version: '3.2.4',
+          path: '/repo/node_modules/.pnpm/vitest@3.2.4/node_modules/vitest',
+        },
+      },
+      node_modules_path: '/repo/node_modules',
+    })
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        name: 'myapp',
+        version: '0.1.0',
+        dependencies: { commander: '^14.0.1' },
+        devDependencies: { vitest: '^3.2.4' },
+      }),
+    )
+
+    const { report } = await reportModule.produceReport('local', {
+      outputFormat: 'json',
+      cwd: '/repo',
+    })
+
+    expect(report.project_name).toBe('myapp')
+    expect(report.local_dependencies[0].name).toBe('commander')
+    expect(report.local_dev_dependencies[0].name).toBe('vitest')
+    expect(report.local_dependencies[0].resolved_path).toMatch(/commander/)
+  })
+
+  it('builds a global report using the resolved pnpm global root', async () => {
+    mockPnpmPmLs.mockResolvedValue({
+      dependencies: {
+        typescript: { version: '5.4.0', path: '/g/node_modules/typescript' },
+      },
+    })
+    mockPnpmRootGlobal.mockResolvedValue('/g/node_modules')
+
+    const { report } = await reportModule.produceReport('global', { outputFormat: 'json' })
+
+    expect(report.global_packages).toEqual([
+      { name: 'typescript', version: '5.4.0', resolved_path: '/g/node_modules/typescript' },
+    ])
+  })
+})

--- a/src/runtimes/pnpm/report.ts
+++ b/src/runtimes/pnpm/report.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Report generation utilities for the pnpm runtime.
+ */
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { buildReportFromNpmTree } from '../../shared/transform.js'
+import type { OutputFormat, Report } from '../../shared/types.js'
+import { getToolVersion } from '../../shared/cli/utils.js'
+
+import { pnpmPmLs, pnpmRootGlobal } from './package-manager.js'
+
+export interface ReportOptions {
+  outputFormat: OutputFormat
+  outFile?: string
+  fullTree?: boolean
+  omitDev?: boolean
+  cwd?: string
+}
+
+export interface ReportResult {
+  report: Report
+  markdownExtras?: {
+    project_description?: string
+    project_homepage?: string
+    project_bugs?: string
+  }
+}
+
+export async function produceReport(
+  ctx: 'local' | 'global',
+  options: ReportOptions,
+): Promise<ReportResult> {
+  const toolVersion = await getToolVersion()
+  const cwd = options.cwd || process.cwd()
+
+  const tree = await pnpmPmLs({
+    global: ctx === 'global',
+    omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
+    cwd,
+  })
+
+  let project_description: string | undefined
+  let project_homepage: string | undefined
+  let project_bugs: string | undefined
+
+  if (ctx === 'local') {
+    try {
+      const pkgRaw = await readFile(path.join(cwd, 'package.json'), 'utf8')
+      const pkg = JSON.parse(pkgRaw)
+      project_description = pkg.description
+      project_homepage = pkg.homepage
+      if (typeof pkg.bugs === 'string') project_bugs = pkg.bugs
+      else if (pkg.bugs && typeof pkg.bugs.url === 'string') project_bugs = pkg.bugs.url
+    } catch {
+      void 0
+    }
+  }
+
+  const globalRoot =
+    ctx === 'global'
+      ? tree.node_modules_path || (await pnpmRootGlobal().catch(() => undefined))
+      : undefined
+
+  const report = await buildReportFromNpmTree(tree, {
+    context: ctx,
+    includeTree: Boolean(options.fullTree),
+    omitDev: Boolean(options.omitDev),
+    cwd,
+    toolVersion,
+    globalRoot,
+  })
+
+  const markdownExtras = { project_description, project_homepage, project_bugs }
+  return { report, markdownExtras }
+}

--- a/src/runtimes/yarn/cli.entry.ts
+++ b/src/runtimes/yarn/cli.entry.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Yarn CLI entrypoint for the `gex-yarn` binary.
+ *
+ * Thin wrapper that invokes the shared Yarn runtime `run` function when the
+ * generated bundle is executed as the main module.
+ */
+
+import { run } from './cli.js'
+
+const isMainModule = (() => {
+  try {
+    if (typeof require !== 'undefined' && typeof module !== 'undefined') {
+      return (require as any).main === module
+    }
+    if (typeof import.meta !== 'undefined') {
+      return import.meta.url === `file://${process.argv[1]}`
+    }
+    return false
+  } catch {
+    return false
+  }
+})()
+
+if (isMainModule) {
+  run().catch((error) => {
+    console.error('Yarn CLI error:', error)
+    process.exitCode = 1
+  })
+}

--- a/src/runtimes/yarn/cli.ts
+++ b/src/runtimes/yarn/cli.ts
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Yarn CLI runner for GEX dependency auditing tool
+ *
+ * This module only exports the `run` function and does not auto-execute
+ * itself. Binary entrypoints (e.g. `cli-yarn`) are responsible for invoking
+ * `run()` when appropriate so this file can be safely imported by other
+ * entrypoints without triggering side effects.
+ */
+
+import { createProgram } from './commands.js'
+
+export async function run(argv = process.argv): Promise<void> {
+  const program = await createProgram()
+  await program.parseAsync(argv)
+}

--- a/src/runtimes/yarn/commands.ts
+++ b/src/runtimes/yarn/commands.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview CLI command definitions and handlers for the Yarn runtime.
+ */
+
+import path from 'node:path'
+
+import { Command } from 'commander'
+
+import type { OutputFormat } from '../../shared/types.js'
+import { installFromReport, printFromReport } from '../../shared/cli/install.js'
+import { outputReport } from '../../shared/cli/output.js'
+import { isMarkdownReportFile, loadReportFromFile } from '../../shared/cli/parser.js'
+import { ASCII_BANNER, getToolVersion } from '../../shared/cli/utils.js'
+
+import { produceReport } from './report.js'
+
+function addCommonOptions(cmd: Command, { allowOmitDev }: { allowOmitDev: boolean }): Command {
+  cmd
+    .option(
+      '-f, --output-format <format>',
+      'Output format: md or json',
+      (val) => (val === 'md' ? 'md' : 'json'),
+      'json',
+    )
+    .option('-o, --out-file <path>', 'Write report to file')
+    .option('--full-tree', 'Include full yarn list tree (when available)', false)
+
+  if (allowOmitDev) {
+    cmd.option('--omit-dev', 'Exclude devDependencies (local only)', false)
+  }
+
+  return cmd
+}
+
+export function createLocalCommand(program: Command): Command {
+  const localCmd = program
+    .command('local', { isDefault: true })
+    .description("Generate a report for the current Yarn project's dependencies")
+
+  addCommonOptions(localCmd, { allowOmitDev: true })
+
+  localCmd.action(async (opts) => {
+    const outputFormat = (opts.outputFormat ?? 'json') as OutputFormat
+    const outFile = opts.outFile as string | undefined
+    const fullTree = Boolean(opts.fullTree)
+    const omitDev = Boolean(opts.omitDev)
+
+    const { report, markdownExtras } = await produceReport('local', {
+      outputFormat,
+      outFile,
+      fullTree,
+      omitDev,
+    })
+
+    await outputReport(report, outputFormat, outFile, markdownExtras)
+  })
+
+  return localCmd
+}
+
+export function createGlobalCommand(program: Command): Command {
+  const globalCmd = program
+    .command('global')
+    .description('Generate a report of globally installed Yarn packages')
+
+  addCommonOptions(globalCmd, { allowOmitDev: false })
+
+  globalCmd.action(async (opts) => {
+    const outputFormat = (opts.outputFormat ?? 'json') as OutputFormat
+    const outFile = opts.outFile as string | undefined
+    const fullTree = Boolean(opts.fullTree)
+
+    const { report, markdownExtras } = await produceReport('global', {
+      outputFormat,
+      outFile,
+      fullTree,
+    })
+
+    await outputReport(report, outputFormat, outFile, markdownExtras)
+  })
+
+  return globalCmd
+}
+
+export function createReadCommand(program: Command): Command {
+  const readCmd = program
+    .command('read')
+    .description(
+      'Read a previously generated report (JSON or Markdown) and either print package names or install them',
+    )
+    .argument('[report]', 'Path to report file (JSON or Markdown)', 'yarn-report.json')
+    .option('-r, --report <path>', 'Path to report file (JSON or Markdown)')
+    .option('-p, --print', 'Print package names/versions from the report (default)', false)
+    .option('-i, --install', 'Install packages from the report using Yarn', false)
+
+  readCmd.action(async (reportArg: string | undefined, opts: any) => {
+    const chosen = (opts.report as string | undefined) || reportArg || 'yarn-report.json'
+    const reportPath = path.resolve(process.cwd(), chosen)
+
+    try {
+      const parsed = await loadReportFromFile(reportPath)
+
+      const doInstall = Boolean(opts.install)
+      const doPrint = Boolean(opts.print) || !doInstall
+
+      if (doPrint) {
+        printFromReport(parsed)
+      }
+      if (doInstall) {
+        await installFromReport(parsed, { cwd: process.cwd(), packageManager: 'yarn' })
+      }
+    } catch (err: any) {
+      const isMd = isMarkdownReportFile(reportPath)
+      const hint = isMd
+        ? 'Try generating a JSON report with: gex-yarn global -f json -o global.json, then: gex-yarn read global.json'
+        : 'Specify a report path with: gex-yarn read <path-to-report.json>'
+      console.error(`Failed to read report at ${reportPath}: ${err?.message || err}`)
+      console.error(hint)
+      process.exitCode = 1
+    }
+  })
+
+  return readCmd
+}
+
+export async function createProgram(): Promise<Command> {
+  const program = new Command()
+    .name('gex-yarn')
+    .description('GEX: Dependency auditing and documentation for Yarn (local and global).')
+    .version(await getToolVersion())
+
+  program.addHelpText('beforeAll', `\n${ASCII_BANNER}`)
+
+  createLocalCommand(program)
+  createGlobalCommand(program)
+  createReadCommand(program)
+
+  return program
+}

--- a/src/runtimes/yarn/package-manager.test.ts
+++ b/src/runtimes/yarn/package-manager.test.ts
@@ -1,0 +1,182 @@
+import { promisify } from 'node:util'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { yarnPmLs, yarnRootGlobal } from './package-manager.js'
+
+const mockReadFile = vi.fn()
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}))
+
+vi.mock('node:util', () => ({
+  promisify: vi.fn(),
+}))
+
+const mockPromisify = vi.mocked(promisify)
+const mockExecFileAsync = vi.fn()
+
+const TREE_LINE = (entries: { name: string; version: string }[]): string =>
+  JSON.stringify({
+    type: 'tree',
+    data: {
+      type: 'list',
+      trees: entries.map((entry) => ({
+        name: `${entry.name}@${entry.version}`,
+        children: [],
+        hint: null,
+        color: 'bold',
+        depth: 0,
+      })),
+    },
+  })
+
+describe('yarn package manager helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPromisify.mockReturnValue(mockExecFileAsync)
+  })
+
+  describe('yarnPmLs (local)', () => {
+    it('splits installed packages into dependencies and devDependencies using package.json', async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { commander: '^14.0.1' },
+          devDependencies: { vitest: '^3.2.4' },
+        }),
+      )
+      const ndjson = [
+        '{"type":"info","data":"yarn list v1.22.19"}',
+        TREE_LINE([
+          { name: 'commander', version: '14.0.1' },
+          { name: 'vitest', version: '3.2.4' },
+        ]),
+      ].join('\n')
+      mockExecFileAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('--version')) return { stdout: '1.22.19\n', stderr: '' }
+        return { stdout: ndjson, stderr: '' }
+      })
+
+      const tree = await yarnPmLs({ cwd: '/repo' })
+
+      expect(tree.dependencies).toEqual({
+        commander: { version: '14.0.1', path: '/repo/node_modules/commander' },
+      })
+      expect(tree.devDependencies).toEqual({
+        vitest: { version: '3.2.4', path: '/repo/node_modules/vitest' },
+      })
+      expect(tree.node_modules_path).toBe('/repo/node_modules')
+    })
+
+    it('omits devDependencies when omitDev is set and passes --prod to yarn', async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { commander: '^14.0.1' },
+          devDependencies: { vitest: '^3.2.4' },
+        }),
+      )
+      const ndjson = TREE_LINE([{ name: 'commander', version: '14.0.1' }])
+
+      mockExecFileAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('--version')) return { stdout: '1.22.19\n', stderr: '' }
+        return { stdout: ndjson, stderr: '' }
+      })
+
+      const tree = await yarnPmLs({ cwd: '/repo', omitDev: true })
+
+      expect(tree.dependencies).toHaveProperty('commander')
+      expect(tree.devDependencies).toBeUndefined()
+
+      const listCall = mockExecFileAsync.mock.calls.find(
+        (call) => Array.isArray(call[1]) && (call[1] as string[]).includes('list'),
+      )
+      expect(listCall?.[1]).toEqual(expect.arrayContaining(['--prod']))
+    })
+
+    it('handles scoped package names in tree entries', async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          dependencies: { '@scope/pkg': '^1.0.0' },
+        }),
+      )
+      const ndjson = TREE_LINE([{ name: '@scope/pkg', version: '1.2.3' }])
+
+      mockExecFileAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('--version')) return { stdout: '1.22.19\n', stderr: '' }
+        return { stdout: ndjson, stderr: '' }
+      })
+
+      const tree = await yarnPmLs({ cwd: '/repo' })
+
+      expect(tree.dependencies).toEqual({
+        '@scope/pkg': { version: '1.2.3', path: '/repo/node_modules/@scope/pkg' },
+      })
+    })
+
+    it('throws a clear error when Yarn Berry is detected', async () => {
+      mockExecFileAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('--version')) return { stdout: '4.5.0\n', stderr: '' }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(yarnPmLs({ cwd: '/repo' })).rejects.toThrow(/Yarn Berry/)
+    })
+  })
+
+  describe('yarnPmLs (global)', () => {
+    it('queries yarn global list for global packages', async () => {
+      const ndjson = TREE_LINE([
+        { name: 'create-react-app', version: '5.0.1' },
+        { name: 'typescript', version: '5.4.0' },
+      ])
+
+      mockExecFileAsync.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('--version')) return { stdout: '1.22.19\n', stderr: '' }
+        if (args[0] === 'global' && args[1] === 'dir') {
+          return { stdout: '/Users/me/.config/yarn/global\n', stderr: '' }
+        }
+        return { stdout: ndjson, stderr: '' }
+      })
+
+      const tree = await yarnPmLs({ global: true })
+
+      expect(tree.dependencies).toEqual({
+        'create-react-app': {
+          version: '5.0.1',
+          path: '/Users/me/.config/yarn/global/node_modules/create-react-app',
+        },
+        typescript: {
+          version: '5.4.0',
+          path: '/Users/me/.config/yarn/global/node_modules/typescript',
+        },
+      })
+      expect(tree.devDependencies).toBeUndefined()
+    })
+  })
+
+  describe('yarnRootGlobal', () => {
+    it('returns the trimmed yarn global node_modules directory', async () => {
+      mockExecFileAsync.mockResolvedValue({
+        stdout: '/Users/me/.config/yarn/global\n',
+        stderr: '',
+      })
+
+      const result = await yarnRootGlobal()
+
+      expect(result).toBe('/Users/me/.config/yarn/global/node_modules')
+    })
+
+    it('throws when yarn global dir fails', async () => {
+      const error = new Error('yarn global dir failed') as any
+      error.stderr = 'yarn ERR'
+      mockExecFileAsync.mockRejectedValue(error)
+
+      await expect(yarnRootGlobal()).rejects.toThrow(/yarn global dir/)
+    })
+  })
+})

--- a/src/runtimes/yarn/package-manager.ts
+++ b/src/runtimes/yarn/package-manager.ts
@@ -1,0 +1,200 @@
+/**
+ * @fileoverview Yarn (Classic) command execution utilities for dependency analysis.
+ *
+ * Targets Yarn 1.x. Yarn Berry (2.x+) uses a different CLI surface and is not
+ * supported here yet — invocations error out with a clear message.
+ */
+
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+export type YarnPmLsOptions = {
+  global?: boolean
+  omitDev?: boolean
+  cwd?: string
+}
+
+type PackageNode = {
+  version: string
+  path: string
+}
+
+type YarnPackageTree = {
+  dependencies: Record<string, PackageNode>
+  devDependencies?: Record<string, PackageNode>
+  node_modules_path?: string
+}
+
+async function getExecFileAsync(): Promise<
+  (
+    command: string,
+    args?: readonly string[] | null,
+    options?: any,
+  ) => Promise<{ stdout: string; stderr: string }>
+> {
+  const { execFile } = await import('node:child_process')
+  return promisify(execFile) as any
+}
+
+async function readJson(file: string): Promise<any | null> {
+  try {
+    const { readFile } = await import('node:fs/promises')
+    const raw = await readFile(file, 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reads `yarn --version` and returns the trimmed string.
+ */
+export async function yarnVersion(cwd?: string): Promise<string> {
+  const execFileAsync = await getExecFileAsync()
+  try {
+    const { stdout } = await execFileAsync('yarn', ['--version'], { cwd })
+    return stdout.trim()
+  } catch (err: any) {
+    const stderr = typeof err?.stderr === 'string' ? err.stderr.trim() : ''
+    const msg = stderr || err?.message || 'yarn --version failed'
+    throw new Error(`yarn --version failed: ${msg}`)
+  }
+}
+
+/**
+ * Returns true when the active yarn binary is Berry (Yarn 2.x+).
+ */
+function isYarnBerry(version: string): boolean {
+  const major = parseInt(version.split('.')[0] || '0', 10)
+  return Number.isFinite(major) && major >= 2
+}
+
+/**
+ * Returns the yarn global root directory (parent of node_modules).
+ */
+export async function yarnRootGlobal(): Promise<string> {
+  const execFileAsync = await getExecFileAsync()
+  try {
+    const { stdout } = await execFileAsync('yarn', ['global', 'dir'])
+    return path.join(stdout.trim(), 'node_modules')
+  } catch (err: any) {
+    const stderr = typeof err?.stderr === 'string' ? err.stderr.trim() : ''
+    const msg = stderr || err?.message || 'yarn global dir failed'
+    throw new Error(`yarn global dir failed: ${msg}`)
+  }
+}
+
+/**
+ * Lists installed packages reported by Yarn Classic.
+ *
+ * Local mode reads package.json to split the flat tree into prod/dev buckets.
+ * Global mode resolves paths under `yarn global dir`/node_modules.
+ */
+export async function yarnPmLs(options: YarnPmLsOptions = {}): Promise<YarnPackageTree> {
+  const execFileAsync = await getExecFileAsync()
+
+  const version = await yarnVersion(options.cwd)
+  if (isYarnBerry(version)) {
+    throw new Error(
+      `Yarn Berry (${version}) is not supported. Use Yarn Classic (1.x) or run gex-node / gex-pnpm.`,
+    )
+  }
+
+  if (options.global) {
+    const globalRoot = await yarnRootGlobal()
+    const args = ['global', 'list', '--json', '--depth=0']
+    const { stdout } = await runYarnList(execFileAsync, args)
+    const trees = parseYarnTrees(stdout)
+    const dependencies: Record<string, PackageNode> = {}
+    for (const entry of trees) {
+      const { name, version: ver } = parseNameVersion(entry)
+      if (!name) continue
+      dependencies[name] = { version: ver, path: packagePath(globalRoot, name) }
+    }
+    return { dependencies, node_modules_path: globalRoot }
+  }
+
+  const cwd = options.cwd || process.cwd()
+  const nodeModulesPath = path.join(cwd, 'node_modules')
+  const manifest = await readJson(path.join(cwd, 'package.json'))
+  const devNames = new Set(Object.keys(manifest?.devDependencies || {}))
+
+  const args = ['list', '--json', '--depth=0']
+  if (options.omitDev) args.push('--prod')
+
+  const { stdout } = await runYarnList(execFileAsync, args, cwd)
+  const trees = parseYarnTrees(stdout)
+
+  const dependencies: Record<string, PackageNode> = {}
+  const devDependencies: Record<string, PackageNode> = {}
+  for (const entry of trees) {
+    const { name, version: ver } = parseNameVersion(entry)
+    if (!name) continue
+    const node = { version: ver, path: packagePath(nodeModulesPath, name) }
+    if (!options.omitDev && devNames.has(name)) {
+      devDependencies[name] = node
+    } else {
+      dependencies[name] = node
+    }
+  }
+
+  return {
+    dependencies,
+    devDependencies: options.omitDev ? undefined : devDependencies,
+    node_modules_path: nodeModulesPath,
+  }
+}
+
+async function runYarnList(
+  execFileAsync: (
+    command: string,
+    args?: readonly string[] | null,
+    options?: any,
+  ) => Promise<{ stdout: string; stderr: string }>,
+  args: readonly string[],
+  cwd?: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await execFileAsync('yarn', args, { cwd, maxBuffer: 10 * 1024 * 1024 })
+  } catch (err: any) {
+    const stdout = typeof err?.stdout === 'string' ? err.stdout : ''
+    if (stdout.trim()) return { stdout, stderr: err?.stderr || '' }
+    const stderr = typeof err?.stderr === 'string' ? err.stderr.trim() : ''
+    const msg = stderr || err?.message || 'yarn list failed'
+    throw new Error(`yarn list failed: ${msg}`)
+  }
+}
+
+function parseYarnTrees(stdout: string): string[] {
+  const names: string[] = []
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let parsed: any
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (parsed && parsed.type === 'tree' && parsed.data && Array.isArray(parsed.data.trees)) {
+      for (const node of parsed.data.trees) {
+        if (node && typeof node.name === 'string') names.push(node.name)
+      }
+    }
+  }
+  return names
+}
+
+function parseNameVersion(spec: string): { name: string; version: string } {
+  const at = spec.lastIndexOf('@')
+  if (at <= 0) return { name: spec, version: '' }
+  return { name: spec.slice(0, at), version: spec.slice(at + 1) }
+}
+
+function packagePath(root: string, name: string): string {
+  if (name.startsWith('@')) {
+    const [scope, sub] = name.split('/')
+    return path.join(root, scope, sub || '')
+  }
+  return path.join(root, name)
+}

--- a/src/runtimes/yarn/report.test.ts
+++ b/src/runtimes/yarn/report.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./package-manager.js', () => ({
+  yarnPmLs: vi.fn(),
+  yarnRootGlobal: vi.fn(),
+}))
+
+const mockReadFile = vi.fn()
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: any[]) => mockReadFile(...args),
+}))
+
+vi.mock('../../shared/cli/utils.js', () => ({
+  getToolVersion: vi.fn().mockResolvedValue('test-tool-version'),
+  ASCII_BANNER: '',
+}))
+
+const pmModule = await import('./package-manager.js')
+const reportModule = await import('./report.js')
+
+const mockYarnPmLs = vi.mocked(pmModule.yarnPmLs)
+const mockYarnRootGlobal = vi.mocked(pmModule.yarnRootGlobal)
+
+describe('yarn produceReport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockReadFile.mockReset()
+  })
+
+  it('builds a local report from the yarn tree', async () => {
+    mockYarnPmLs.mockResolvedValue({
+      dependencies: { commander: { version: '14.0.1', path: '/repo/node_modules/commander' } },
+      devDependencies: { vitest: { version: '3.2.4', path: '/repo/node_modules/vitest' } },
+      node_modules_path: '/repo/node_modules',
+    })
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        name: 'myapp',
+        version: '0.1.0',
+        description: 'desc',
+        homepage: 'https://example.test',
+        bugs: 'https://example.test/issues',
+        dependencies: { commander: '^14.0.1' },
+        devDependencies: { vitest: '^3.2.4' },
+      }),
+    )
+
+    const { report, markdownExtras } = await reportModule.produceReport('local', {
+      outputFormat: 'json',
+      cwd: '/repo',
+    })
+
+    expect(report.tool_version).toBe('test-tool-version')
+    expect(report.project_name).toBe('myapp')
+    expect(report.local_dependencies).toEqual([
+      { name: 'commander', version: '14.0.1', resolved_path: '/repo/node_modules/commander' },
+    ])
+    expect(report.local_dev_dependencies).toEqual([
+      { name: 'vitest', version: '3.2.4', resolved_path: '/repo/node_modules/vitest' },
+    ])
+    expect(markdownExtras?.project_description).toBe('desc')
+  })
+
+  it('builds a global report using the resolved yarn global root', async () => {
+    mockYarnPmLs.mockResolvedValue({
+      dependencies: {
+        typescript: {
+          version: '5.4.0',
+          path: '/Users/me/.config/yarn/global/node_modules/typescript',
+        },
+      },
+      node_modules_path: '/Users/me/.config/yarn/global/node_modules',
+    })
+    mockYarnRootGlobal.mockResolvedValue('/Users/me/.config/yarn/global/node_modules')
+
+    const { report } = await reportModule.produceReport('global', { outputFormat: 'json' })
+
+    expect(report.global_packages).toEqual([
+      {
+        name: 'typescript',
+        version: '5.4.0',
+        resolved_path: '/Users/me/.config/yarn/global/node_modules/typescript',
+      },
+    ])
+    expect(report.local_dependencies).toEqual([])
+  })
+})

--- a/src/runtimes/yarn/report.ts
+++ b/src/runtimes/yarn/report.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Report generation utilities for the Yarn runtime.
+ */
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { buildReportFromNpmTree } from '../../shared/transform.js'
+import type { OutputFormat, Report } from '../../shared/types.js'
+import { getToolVersion } from '../../shared/cli/utils.js'
+
+import { yarnPmLs, yarnRootGlobal } from './package-manager.js'
+
+export interface ReportOptions {
+  outputFormat: OutputFormat
+  outFile?: string
+  fullTree?: boolean
+  omitDev?: boolean
+  cwd?: string
+}
+
+export interface ReportResult {
+  report: Report
+  markdownExtras?: {
+    project_description?: string
+    project_homepage?: string
+    project_bugs?: string
+  }
+}
+
+export async function produceReport(
+  ctx: 'local' | 'global',
+  options: ReportOptions,
+): Promise<ReportResult> {
+  const toolVersion = await getToolVersion()
+  const cwd = options.cwd || process.cwd()
+
+  const tree = await yarnPmLs({
+    global: ctx === 'global',
+    omitDev: ctx === 'local' ? Boolean(options.omitDev) : false,
+    cwd,
+  })
+
+  let project_description: string | undefined
+  let project_homepage: string | undefined
+  let project_bugs: string | undefined
+
+  if (ctx === 'local') {
+    try {
+      const pkgRaw = await readFile(path.join(cwd, 'package.json'), 'utf8')
+      const pkg = JSON.parse(pkgRaw)
+      project_description = pkg.description
+      project_homepage = pkg.homepage
+      if (typeof pkg.bugs === 'string') project_bugs = pkg.bugs
+      else if (pkg.bugs && typeof pkg.bugs.url === 'string') project_bugs = pkg.bugs.url
+    } catch {
+      void 0
+    }
+  }
+
+  const globalRoot =
+    ctx === 'global'
+      ? tree.node_modules_path || (await yarnRootGlobal().catch(() => undefined))
+      : undefined
+
+  const report = await buildReportFromNpmTree(tree, {
+    context: ctx,
+    includeTree: Boolean(options.fullTree),
+    omitDev: Boolean(options.omitDev),
+    cwd,
+    toolVersion,
+    globalRoot,
+  })
+
+  const markdownExtras = { project_description, project_homepage, project_bugs }
+  return { report, markdownExtras }
+}

--- a/src/shared/cli/install.test.ts
+++ b/src/shared/cli/install.test.ts
@@ -81,6 +81,54 @@ describe('installFromReport', () => {
     )
   })
 
+  it('installs packages with yarn when requested', async () => {
+    await installFromReport(baseReport, { cwd: '/tmp/project', packageManager: 'yarn' })
+
+    expect(execFileAsync).toHaveBeenCalledTimes(3)
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      1,
+      'yarn',
+      ['global', 'add', '@scope/pkg@1.0.0'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      2,
+      'yarn',
+      ['add', 'dep@2.0.0'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      3,
+      'yarn',
+      ['add', '-D', 'dev-dep'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+  })
+
+  it('installs packages with pnpm when requested', async () => {
+    await installFromReport(baseReport, { cwd: '/tmp/project', packageManager: 'pnpm' })
+
+    expect(execFileAsync).toHaveBeenCalledTimes(3)
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      1,
+      'pnpm',
+      ['add', '-g', '@scope/pkg@1.0.0'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      2,
+      'pnpm',
+      ['add', 'dep@2.0.0'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+    expect(execFileAsync).toHaveBeenNthCalledWith(
+      3,
+      'pnpm',
+      ['add', '-D', 'dev-dep'],
+      expect.objectContaining({ cwd: '/tmp/project' }),
+    )
+  })
+
   it('skips installation when no packages are present', async () => {
     await installFromReport(
       {

--- a/src/shared/cli/install.ts
+++ b/src/shared/cli/install.ts
@@ -4,7 +4,7 @@
 
 import type { Report } from '../types.js'
 
-type PackageManager = 'npm' | 'bun'
+type PackageManager = 'npm' | 'bun' | 'yarn' | 'pnpm'
 
 export type InstallOptions = {
   cwd: string
@@ -24,6 +24,16 @@ const INSTALL_COMMANDS: Record<
     global: ['add', '-g'],
     local: ['add'],
     dev: ['add', '-d'],
+  },
+  yarn: {
+    global: ['global', 'add'],
+    local: ['add'],
+    dev: ['add', '-D'],
+  },
+  pnpm: {
+    global: ['add', '-g'],
+    local: ['add'],
+    dev: ['add', '-D'],
   },
 }
 
@@ -74,7 +84,7 @@ export async function installFromReport(
   // Acquire execFileAsync once per run to keep logs grouped, while still mockable in tests
   const execFileAsync = await getExecFileAsync()
   const cmd = INSTALL_COMMANDS[packageManager]
-  const binary = packageManager === 'bun' ? 'bun' : 'npm'
+  const binary = packageManager === 'npm' ? 'npm' : packageManager
 
   if (globalPkgs.length > 0) {
     console.log(`Installing global: ${globalPkgs.join(' ')}`)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -62,4 +62,36 @@ export default defineConfig([
       return { js: '.mjs' }
     },
   },
+  // Yarn runtime CLI
+  {
+    entry: { 'cli-yarn': 'src/runtimes/yarn/cli.entry.ts' },
+    format: ['esm', 'cjs'],
+    dts: false,
+    sourcemap: true,
+    clean: false,
+    target: 'node18',
+    outDir: 'dist',
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+    outExtension({ format }) {
+      return { js: format === 'cjs' ? '.cjs' : '.mjs' }
+    },
+  },
+  // pnpm runtime CLI
+  {
+    entry: { 'cli-pnpm': 'src/runtimes/pnpm/cli.entry.ts' },
+    format: ['esm', 'cjs'],
+    dts: false,
+    sourcemap: true,
+    clean: false,
+    target: 'node18',
+    outDir: 'dist',
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+    outExtension({ format }) {
+      return { js: format === 'cjs' ? '.cjs' : '.mjs' }
+    },
+  },
 ])


### PR DESCRIPTION
## Summary

- Adds `gex-yarn` (Yarn Classic 1.x) and `gex-pnpm` binaries, mirroring the existing `gex-node` / `gex-bun` runtime split.
- New runtimes reuse the shared report renderers and `buildReportFromNpmTree` transform; only the package-manager wrapper differs.
- Detects Yarn Berry (2.x+) via `yarn --version` and exits with a clear error pointing users at `gex-node` / `gex-pnpm` — Berry uses an entirely different CLI surface and is out of scope here.
- `read --install` now supports `yarn` and `pnpm` package managers in addition to `npm` / `bun`.

### Implementation notes

- `src/runtimes/yarn/package-manager.ts`
  - `yarnPmLs` invokes `yarn list --json --depth=0` (NDJSON, classic) and parses the `tree` line's `data.trees`.
  - `--prod` is added when `omitDev` is set; otherwise the flat tree is split into prod / dev buckets using `package.json` declarations (Yarn Classic doesn't tag entries by type).
  - Global mode resolves paths under `yarn global dir`/`node_modules` and runs `yarn global list --json --depth=0`.
  - Berry detection is centralized in a single early check.
- `src/runtimes/pnpm/package-manager.ts`
  - `pnpmPmLs` invokes `pnpm list --json --depth=0` (JSON array) and reads the first element's `dependencies` / `devDependencies`, which already match the npm-tree shape (`{ name: { version, path } }`).
  - `--global` and `--prod` flags are forwarded; `pnpm root -g` is used when a global `node_modules_path` isn't returned.
- Both runtimes use the same lazy `execFile` import pattern as `src/shared/npm-cli.ts` so tests can mock `node:child_process` reliably.
- `tsup.config.ts` adds two CJS+ESM CLI bundles. `package.json` `bin` registers `gex-yarn` → `dist/cli-yarn.cjs` and `gex-pnpm` → `dist/cli-pnpm.cjs`.

### Out of scope

- Outdated / update workflows for yarn and pnpm (no shared `yarnOutdated` / `pnpmOutdated` helpers yet — `--check-outdated` / `--update-outdated` are intentionally not added to these CLIs in this PR).
- Lockfile detection / auto-routing across runtimes (FEATURES.md keeps that as a separate, future feature).
- Yarn Berry support — flagged as a clear error rather than half-implemented.

## Test plan

- [x] `bun run test` — 220/220 pass (was 199, +21 new across `runtimes/yarn/`, `runtimes/pnpm/`, and `shared/cli/install.test.ts`).
- [x] `bun run lint` clean.
- [x] `bun run build` clean — produces `dist/cli-yarn.{cjs,mjs}` and `dist/cli-pnpm.{cjs,mjs}` alongside the existing bundles.
- [x] Smoke: `node dist/cli-yarn.cjs --help` and `node dist/cli-pnpm.cjs --help` print the expected banner and command list.
- [x] Smoke: `node dist/cli-pnpm.cjs local -f md` against this repo runs cleanly (output is project metadata only because this repo is Bun-managed and pnpm reports zero installed packages — the wrapper handles that gracefully).
- [x] Smoke: `node dist/cli-yarn.cjs local -f md` runs cleanly. Yarn 1.x errored on this repo's `.npmrc` `${NPM_TOKEN}` env interpolation; the wrapper's `runYarnList` recovers stdout from the error path so the run still completes without throwing.

## Notes

Independent of #21 (audit), #22 (diff), #23 (license inventory), #24 (--from-lockfile). When all five merge, `gex-yarn` and `gex-pnpm` will pick up the audit / diff / license / lockfile features automatically since they all consume the same `Report` shape and the audit / license / lockfile work attaches to the shared workflow layer.